### PR TITLE
Fixed Cocoapods smart quotes warning

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,33 +9,33 @@ target 'Slide for Reddit' do
   pod 'reddift', :git =>  'https://github.com/ccrama/reddift'
   pod 'SDWebImage', '~>3.8'
   pod 'SideMenu'
-pod 'MaterialComponents/AnimationTiming'
-pod 'MaterialComponents/Buttons'
-pod 'MaterialComponents/Dialogs'
-pod 'MaterialComponents/Ink'
-pod 'MaterialComponents/Palettes'
-pod 'MaterialComponents/TextFields'
-pod 'MaterialComponents/BottomSheet'
-pod 'MaterialComponents/ProgressView' 
-pod "MKColorPicker"
-pod 'BadgeSwift', '~> 5.0'
-pod 'LicensesViewController', '~> 0.6.5'
-pod 'BiometricAuthentication'
+  pod 'MaterialComponents/AnimationTiming'
+  pod 'MaterialComponents/Buttons'
+  pod 'MaterialComponents/Dialogs'
+  pod 'MaterialComponents/Ink'
+  pod 'MaterialComponents/Palettes'
+  pod 'MaterialComponents/TextFields'
+  pod 'MaterialComponents/BottomSheet'
+  pod 'MaterialComponents/ProgressView'
+  pod 'MKColorPicker'
+  pod 'BadgeSwift', '~> 5.0'
+  pod 'LicensesViewController', '~> 0.6.5'
+  pod 'BiometricAuthentication'
   pod 'XLActionController', :git => 'https://github.com/ccrama/XLActionController'
-pod 'MaterialComponents/ShadowElevations'
-pod 'MaterialComponents/Snackbar’
-pod 'MaterialComponents/ActivityIndicator'
-pod "SwiftSpreadsheet"
-pod 'Starscream', '~> 3.0.2'
-pod 'MaterialComponents/Tabs'
-  pod “RLBAlertsPickers”, :git => ‘https://github.com/ccrama/Alerts-Pickers'
-  pod “SloppySwiper”, :git => ‘https://github.com/fastred/SloppySwiper'
+  pod 'MaterialComponents/ShadowElevations'
+  pod 'MaterialComponents/Snackbar'
+  pod 'MaterialComponents/ActivityIndicator'
+  pod 'SwiftSpreadsheet'
+  pod 'Starscream', '~> 3.0.2'
+  pod 'MaterialComponents/Tabs'
+  pod 'RLBAlertsPickers', :git => 'https://github.com/ccrama/Alerts-Pickers'
+  pod 'SloppySwiper', :git => 'https://github.com/fastred/SloppySwiper'
   pod 'UZTextView', :git => 'https://github.com/ccrama/UZTextView'
   pod 'TTTAttributedLabel'
   pod 'Alamofire', '~> 4.3'
-    pod 'SwiftyJSON'
-pod 'ActionSheetPicker-3.0’, :git => ‘https://github.com/ccrama/ActionSheetPicker-3.0'
-  pod ‘RealmSwift’
+  pod 'SwiftyJSON'
+  pod 'ActionSheetPicker-3.0', :git => 'https://github.com/ccrama/ActionSheetPicker-3.0'
+  pod 'RealmSwift'
 
   target 'Slide for RedditTests' do
     inherit! :search_paths
@@ -50,9 +50,9 @@ pod 'ActionSheetPicker-3.0’, :git => ‘https://github.com/ccrama/ActionSheetP
 end
 
 post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['SWIFT_VERSION'] = '3.0'
-        end
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['SWIFT_VERSION'] = '3.0'
     end
   end
+end


### PR DESCRIPTION
I just saw this little warning after running `pod install`.

![screen shot 2018-06-19 at 17 00 32](https://user-images.githubusercontent.com/4272387/41606588-49cad894-73e4-11e8-8aea-a8788de4a8cb.png)

It was just a problem with some smart quotes characters, not a big deal. Some indents have also been added to make it look cleaner.

Great work with the app, btw! 👍