### PR TITLE
Add flat mode

### DIFF
--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -160,13 +160,17 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
         self.thumbImageContainer = UIView().then {
             $0.accessibilityIdentifier = "Thumbnail Image Container"
             $0.frame = CGRect(x: 0, y: 8, width: (SettingValues.largerThumbnail ? 75 : 50) - (SettingValues.postViewMode == .COMPACT ? 15 : 0), height: (SettingValues.largerThumbnail ? 75 : 50) - (SettingValues.postViewMode == .COMPACT ? 15 : 0))
-            $0.elevate(elevation: 2.0)
+            if !SettingValues.flatMode {
+                $0.elevate(elevation: 2.0)
+            }
         }
 
         self.thumbImage = UIImageView().then {
             $0.accessibilityIdentifier = "Thumbnail Image"
             $0.backgroundColor = UIColor.white
-            $0.layer.cornerRadius = 10
+            if !SettingValues.flatMode {
+                $0.layer.cornerRadius = 10
+            }
             $0.contentMode = .scaleAspectFill
             $0.clipsToBounds = true
         }
@@ -176,7 +180,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
         self.bannerImage = UIImageView().then {
             $0.accessibilityIdentifier = "Banner Image"
             $0.contentMode = .scaleAspectFill
-            $0.layer.cornerRadius = 15
+            if !SettingValues.flatMode {
+                $0.layer.cornerRadius = 15
+            }
             $0.clipsToBounds = true
             $0.backgroundColor = UIColor.white
         }
@@ -320,7 +326,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
             $0.accessibilityIdentifier = "Tag Body"
             $0.backgroundColor = UIColor.white
             $0.clipsToBounds = true
-            $0.layer.cornerRadius = 4
+            if !SettingValues.flatMode {
+                $0.layer.cornerRadius = 4
+            }
         }
 
         self.info = UILabel().then {
@@ -334,7 +342,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
             $0.accessibilityIdentifier = "Banner Info Container"
             $0.backgroundColor = UIColor.black.withAlphaComponent(0.6)
             $0.clipsToBounds = true
+            if !SettingValues.flatMode {
             $0.layer.cornerRadius = 15
+            }
         }
 
         if (!addTouch) {
@@ -466,7 +476,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
 
             self.contentView.layoutMargins = UIEdgeInsets.init(top: CGFloat(topmargin), left: CGFloat(leftmargin), bottom: CGFloat(bottommargin), right: CGFloat(rightmargin))
 
-            self.contentView.layer.cornerRadius = CGFloat(radius)
+            if !SettingValues.flatMode {
+                self.contentView.layer.cornerRadius = CGFloat(radius)
+            }
             
             if(SettingValues.actionBarMode == .FULL || full){
                 box.leftAnchor == contentView.leftAnchor + ctwelve
@@ -1326,7 +1338,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, TT
             bottommargin = 5
             leftmargin = 5
             rightmargin = 5
-            self.contentView.elevate(elevation: 2)
+            if !SettingValues.flatMode {
+                self.contentView.elevate(elevation: 2)
+            }
         }
 
         let f = self.contentView.frame

--- a/Slide for Reddit/SettingValues.swift
+++ b/Slide for Reddit/SettingValues.swift
@@ -85,6 +85,7 @@ class SettingValues {
     public static let pref_postImageMode = "POST_IMAGE_MODE"
     public static let pref_linkAlwaysThumbnail = "LINK_ALWAYS_THUMBNAIL"
     public static let pref_actionbarMode = "ACTIONBAR_MODE"
+    public static let pref_flatMode = "FLAT_MODE"
 
     public static var commentActionRight = CommentAction.UPVOTE
     public static var commentActionLeft = CommentAction.DOWNVOTE
@@ -103,6 +104,7 @@ class SettingValues {
     public static var postViewMode = PostViewType.LIST
     public static var postImageMode = PostImageMode.CROPPED_IMAGE
     public static var actionBarMode = ActionBarMode.FULL
+    public static var flatMode = false
     public static var fabType = FabType.HIDE_READ
     public static var pictureMode = "PICTURE_MODE"
     public static var hideImageSelftext = false
@@ -324,6 +326,7 @@ class SettingValues {
         SettingValues.scoreInTitle = settings.bool(forKey: SettingValues.pref_scoreInTitle)
         SettingValues.postViewMode = PostViewType.init(rawValue: settings.string(forKey: SettingValues.pref_postViewMode) ?? "card") ?? .CARD
         SettingValues.actionBarMode = ActionBarMode.init(rawValue: settings.string(forKey: SettingValues.pref_actionbarMode) ?? "full") ?? .FULL
+        SettingValues.flatMode = settings.bool(forKey: SettingValues.pref_flatMode)
         SettingValues.postImageMode = PostImageMode.init(rawValue: settings.string(forKey: SettingValues.pref_postImageMode) ?? "cropped") ?? .CROPPED_IMAGE
         SettingValues.fabType = FabType.init(rawValue: settings.string(forKey: SettingValues.pref_fabType) ?? "hide") ?? .HIDE_READ
         

--- a/Slide for Reddit/SettingsLayout.swift
+++ b/Slide for Reddit/SettingsLayout.swift
@@ -16,7 +16,10 @@ class SettingsLayout: UITableViewController {
     
     var cardModeCell: UITableViewCell = UITableViewCell.init(style: .subtitle, reuseIdentifier: "mode")
     
-    var actionBarCell: UITableViewCell = UITableViewCell.init(style: .subtitle, reuseIdentifier: "mode")
+    var actionBarCell: UITableViewCell = UITableViewCell.init(style: .subtitle, reuseIdentifier: "mode") // TODO: Should this have a different reuseIdentifier?
+
+    var flatModeCell: UITableViewCell = UITableViewCell()
+    var flatMode = UISwitch()
 
     var largerThumbnailCell: UITableViewCell = UITableViewCell()
     var largerThumbnail = UISwitch()
@@ -101,6 +104,9 @@ class SettingsLayout: UITableViewController {
         } else if(changed == save){
             SettingValues.saveButton = changed.isOn
             UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_saveButton)
+        } else if(changed == flatMode){
+            SettingValues.flatMode = changed.isOn
+            UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_flatMode)
         }
         UserDefaults.standard.synchronize()
         doDisables()
@@ -420,6 +426,7 @@ class SettingsLayout: UITableViewController {
         createCell(hideCell, hide, isOn: SettingValues.hideButton, text: "Show hide post button")
         createCell(saveCell, save, isOn: SettingValues.saveButton, text: "Show save button")
         createCell(thumbLinkCell, thumbLink, isOn: SettingValues.linkAlwaysThumbnail, text: "Always show thumbnail on link posts")
+        createCell(flatModeCell, flatMode, isOn: SettingValues.flatMode, text: "Flat Mode")
 
         doDisables()
         self.tableView.tableFooterView = UIView()
@@ -475,8 +482,9 @@ class SettingsLayout: UITableViewController {
             case 4: return self.thumbLinkCell
             case 5: return self.selftextCell
             case 6: return self.smalltagCell
+            case 7: return self.flatModeCell
                 
-            default: fatalError("Unknown row in section 0")
+            default: fatalError("Unknown row in section 1")
             }
         case 2:
             switch(indexPath.row) {
@@ -487,7 +495,7 @@ class SettingsLayout: UITableViewController {
             case 4: return self.hideCell
             case 5: return self.saveCell
                 
-            default: fatalError("Unknown row in section 0")
+            default: fatalError("Unknown row in section 2")
             }
         default: fatalError("Unknown section")
         }
@@ -496,7 +504,7 @@ class SettingsLayout: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch(section) {
         case 0: return 1
-        case 1: return 7
+        case 1: return 8
         case 2: return 6
         default: fatalError("Unknown number of sections")
         }


### PR DESCRIPTION
Side note: right now, changing to flat mode doesn't trigger any loaded cells to rebuild, so for it to show up the app needs to be restarted. This is the case for most of the toggles in `SettingsLayout`. Is there a way we can force all cells to rebuild when we do a settings change?