### PR TITLE
Maintain the collapse state of single comments

### DIFF
--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -2014,10 +2014,16 @@ override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexP
                             self.tableView.beginUpdates()
                             cell.expandSingle()
                             self.tableView.endUpdates()
+                            if hiddenPersons.contains((id)) {
+                                hiddenPersons.remove(at: hiddenPersons.index(of: id)!)
+                            }
                         } else {
                             self.tableView.beginUpdates()
                             cell.collapse(childNumber: 0)
                             self.tableView.endUpdates()
+                            if !hiddenPersons.contains(id) {
+                                hiddenPersons.insert(id)
+                            }
                         }
                     } else {
                         if hiddenPersons.contains((id)) && childNumber > 0 {


### PR DESCRIPTION
When "Collapse comments fully" is set, single comments (without replies) don't maintain their collapse state when scrolled out and back into view. This change fixes the issue.