### PR TITLE
Account for `before` and `links.count` potentially being equal when getting more submissions

### DIFF
--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1010,7 +1010,7 @@ class SingleSubredditViewController: MediaViewController {
                                             updated = listing.updated
                                         }
                                         var paths = [IndexPath]()
-                                        for i in 0...(self.links.count - 1) {
+                                        for i in 0..<self.links.count {
                                             paths.append(IndexPath.init(item: i, section: 0))
                                         }
                                         self.flowLayout.reset()
@@ -1092,7 +1092,7 @@ class SingleSubredditViewController: MediaViewController {
                                 }
                             } else {
                                 var paths = [IndexPath]()
-                                for i in before...(self.links.count - 1) {
+                                for i in before..<self.links.count {
                                     paths.append(IndexPath.init(item: i, section: 0))
                                 }
 


### PR DESCRIPTION
When getting more submissions, the app can crash (rarely) if `values` is empty here: https://github.com/ccrama/Slide-iOS/blob/1fc801fff0fe289b6fb21597a30a566f72dfef13/Slide%20for%20Reddit/SingleSubredditViewController.swift#L1058 with the following error: `Thread 1: Fatal error: Can't form Range with upperBound < lowerBound` at this line: https://github.com/djjcast/Slide-iOS/blob/1fc801fff0fe289b6fb21597a30a566f72dfef13/Slide%20for%20Reddit/SingleSubredditViewController.swift#L1095