### PR TITLE
Add safe area calculation and improve header bar sizing in landscape

### DIFF
--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -1930,29 +1930,34 @@ class CommentViewController: MediaTableViewController, TTTAttributedCellDelegate
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        if let header = self.tableView.tableHeaderView {
-            var frame = header.frame
-            var leftInset: CGFloat = 0
-            var rightInset: CGFloat = 0
-            
-            if #available(iOS 11.0, *) {
-                leftInset = self.tableView.safeAreaInsets.left
-                rightInset = self.tableView.safeAreaInsets.right
-                frame.origin.x = leftInset
-            } else {
-                // Fallback on earlier versions
-            }
-            
-            self.headerCell!.aspectWidth = size.width - (leftInset + rightInset)
-            
-            frame.size.width = size.width - (leftInset + rightInset)
-            frame.size.height = self.headerCell!.estimateHeight(true, true)
-            
-            self.headerCell!.contentView.frame = frame
-            self.tableView.tableHeaderView!.frame = frame
-            tableView.reloadData(with: .none)
-            doHeadView(size)
-        }
+
+        coordinator.animate(
+            alongsideTransition: { [unowned self] _ in
+                if let header = self.tableView.tableHeaderView {
+                    var frame = header.frame
+                    var leftInset: CGFloat = 0
+                    var rightInset: CGFloat = 0
+
+                    if #available(iOS 11.0, *) {
+                        leftInset = self.tableView.safeAreaInsets.left
+                        rightInset = self.tableView.safeAreaInsets.right
+                        frame.origin.x = leftInset
+                    } else {
+                        // Fallback on earlier versions
+                    }
+
+                    self.headerCell!.aspectWidth = size.width - (leftInset + rightInset)
+
+                    frame.size.width = size.width - (leftInset + rightInset)
+                    frame.size.height = self.headerCell!.estimateHeight(true, true)
+
+                    self.headerCell!.contentView.frame = frame
+                    self.tableView.tableHeaderView!.frame = frame
+                    self.tableView.reloadData(with: .none)
+                    self.doHeadView(size)
+                    self.view.setNeedsLayout()
+                }
+            }, completion: nil)
     }
     
     var lastYUsed = CGFloat(0)

--- a/Slide for Reddit/ContentListingViewController.swift
+++ b/Slide for Reddit/ContentListingViewController.swift
@@ -128,6 +128,18 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         }
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        oldsize = self.view.bounds.width
+        coordinator.animate(
+            alongsideTransition: { [unowned self] _ in
+                self.flowLayout.reset()
+                self.view.setNeedsLayout()
+            }, completion: nil
+        )
+    }
+
     var tC: UIViewController?
 
     override func didReceiveMemoryWarning() {

--- a/Slide for Reddit/ContentListingViewController.swift
+++ b/Slide for Reddit/ContentListingViewController.swift
@@ -80,6 +80,8 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         self.tableView = UICollectionView(frame: CGRect.zero, collectionViewLayout: flowLayout)
         self.view = UIView.init(frame: CGRect.zero)
         self.view.addSubview(tableView)
+        tableView.verticalAnchors == view.verticalAnchors
+        tableView.horizontalAnchors == view.safeHorizontalAnchors
 
         self.tableView.delegate = self
         self.tableView.dataSource = self
@@ -109,13 +111,16 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         self.tableView.contentInset = UIEdgeInsets.init(top: CGFloat(top), left: 0, bottom: 65, right: 0)
         
         session = (UIApplication.shared.delegate as! AppDelegate).session
+
+        flowLayout.reset()
+        tableView.reloadData()
     }
     
     var oldsize = CGFloat(0)
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        tableView.frame = self.view.bounds
+
         if self.view.bounds.width != oldsize {
             oldsize = self.view.bounds.width
             flowLayout.reset()

--- a/Slide for Reddit/MainViewController.swift
+++ b/Slide for Reddit/MainViewController.swift
@@ -603,7 +603,7 @@ class MainViewController: ColorMuxPagingViewController, UIPageViewControllerData
     }
 
     var statusbarHeight: CGFloat {
-        return UIApplication.shared.statusBarFrame.size.height
+        return self.navigationController?.navigationBar.frame.height ?? 0.0
     }
     
     func doLogin(token: OAuth2Token?) {
@@ -623,12 +623,11 @@ class MainViewController: ColorMuxPagingViewController, UIPageViewControllerData
         menuNav?.dismiss(animated: true)
     }
 
-    override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
 
         tabBar.width = self.view.frame.size.width
         tabBar.height = statusbarHeight
-        tabBar.sizeToFit()
 
         menuNav?.view.width = splitViewController == nil ? view.frame.width : splitViewController!.primaryColumnWidth
     }
@@ -642,7 +641,6 @@ class MainViewController: ColorMuxPagingViewController, UIPageViewControllerData
     func doCurrentPage(_ page: Int) {
         self.currentPage = page
         if let vc = getSubredditVC() {
-            vc.doHeadView()
             MainViewController.current = vc.sub
             self.menuNav?.setSubreddit(subreddit: MainViewController.current)
             self.currentTitle = MainViewController.current

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -330,8 +330,13 @@ class SingleSubredditViewController: MediaViewController {
 
         inHeadView?.isHidden = UIDevice.current.orientation.isLandscape
 
-        flowLayout.reset()
-        tableView.reloadData()
+        oldsize = self.view.bounds.width
+        coordinator.animate(
+            alongsideTransition: { [unowned self] _ in
+                self.flowLayout.reset()
+                self.view.setNeedsLayout()
+            }, completion: nil
+        )
 
 //        if self.viewIfLoaded?.window != nil {
 //            tableView.reloadData()


### PR DESCRIPTION
This brings back resizing the ContentListingVC and SingleSubredditVC with safe areas in account, this time via AL and without jumping issues. This update also improves the "header" view we're using to cover the status bar by both sizing with AL and hiding itself completely in landscape.