### PR TITLE
* fix crash bug when url contains special character

### DIFF
--- a/Slide for Reddit/MessageCellView.swift
+++ b/Slide for Reddit/MessageCellView.swift
@@ -217,7 +217,7 @@ class MessageCellView: UICollectionViewCell, UIGestureRecognizerDelegate, TextDi
             if self.message!.wasComment {
                 alertController.addAction(Action(ActionData(title: "Full thread", image: UIImage(named: "comments")!.menuIcon()), style: .default, handler: { _ in
                     let url = "https://www.reddit.com\(self.message!.context)"
-                    VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.init(string: url)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
+                    VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: url)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
                 }))
             }
 
@@ -273,7 +273,7 @@ class MessageCellView: UICollectionViewCell, UIGestureRecognizerDelegate, TextDi
         } else {
             if (message?.wasComment)! {
                 let url = "https://www.reddit.com\(message!.context)"
-                let vc = RedditLink.getViewControllerForURL(urlS: URL.init(string: url)!)
+                let vc = RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: url)!)
                 VCPresenter.showVC(viewController: vc, popupIfPossible: true, parentNavigationController: parentViewController?.navigationController, parentViewController: parentViewController)
             } else {
                 VCPresenter.presentAlert(TapBehindModalViewController.init(rootViewController: ReplyViewController.init(message: message, completion: {(_) in

--- a/Slide for Reddit/VCPresenter.swift
+++ b/Slide for Reddit/VCPresenter.swift
@@ -189,7 +189,7 @@ public class VCPresenter {
     }
 
     public static func openRedditLink(_ link: String, _ parentNav: UINavigationController?, _ parentVC: UIViewController?) {
-        let vc = RedditLink.getViewControllerForURL(urlS: URL.init(string: link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!)
+        let vc = RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: link)!)
         showVC(viewController: vc, popupIfPossible: true, parentNavigationController: parentNav, parentViewController: parentVC)
 
     }
@@ -205,4 +205,12 @@ public class DefaultGestureDelegate: NSObject, UIGestureRecognizerDelegate {
 public class UIButtonWithContext: UIButton {
     public var parentController: UINavigationController?
     public var contextController: UIViewController?
+}
+
+extension URL {
+    static func initPercent(string: String) -> URL? {
+        let urlwithPercentEscapes = string.addingPercentEncoding( withAllowedCharacters: .urlQueryAllowed)
+        let url = URL.init(string: urlwithPercentEscapes!)
+        return url
+    }
 }

--- a/Slide for Reddit/VCPresenter.swift
+++ b/Slide for Reddit/VCPresenter.swift
@@ -189,7 +189,7 @@ public class VCPresenter {
     }
 
     public static func openRedditLink(_ link: String, _ parentNav: UINavigationController?, _ parentVC: UIViewController?) {
-        let vc = RedditLink.getViewControllerForURL(urlS: URL.init(string: link)!)
+        let vc = RedditLink.getViewControllerForURL(urlS: URL.init(string: link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!)
         showVC(viewController: vc, popupIfPossible: true, parentNavigationController: parentNav, parentViewController: parentVC)
 
     }


### PR DESCRIPTION
 Fix crash bug when url contains special character in user overview or comment history 

This bug also happens in many code places where "URL.init(string: url)" is used. Maybe a wrapper or extension on URL.init() should be a solution.

[test url](https://reddit.com/r/saraba1st/comments/athotk/%E6%8E%A8%E7%89%B9%E4%B8%8A%E6%90%9C%E7%8E%8B%E6%9E%97%E6%B8%85/)