### PR TITLE
Feature/migrate to swift 5 with pods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -45,4 +45,14 @@ target 'Slide for Reddit' do
     # Pods for testing
   end
 
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        if ['Embassy', 'HTMLSpecialCharacters', 'MiniKeychain'].include? target.name
+            target.build_configurations.each do |config|
+                config.build_settings['SWIFT_VERSION'] = '4.2'
+            end
+        end
+    end
+  end
+
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,52 +1,59 @@
 PODS:
-  - Alamofire (4.8.2)
+  - Alamofire (4.9.0)
   - Anchorage (4.3.1)
   - BadgeSwift (7.0.0)
   - BiometricAuthentication (3.0)
-  - DTCoreText (1.6.22):
-    - DTCoreText/Core (= 1.6.22)
+  - DTCoreText (1.6.23):
+    - DTCoreText/Core (= 1.6.23)
     - DTFoundation/Core (~> 1.7.5)
     - DTFoundation/DTAnimatedGIF (~> 1.7.5)
     - DTFoundation/DTHTMLParser (~> 1.7.5)
     - DTFoundation/UIKit (~> 1.7.5)
-  - DTCoreText/Core (1.6.22):
+  - DTCoreText/Core (1.6.23):
     - DTFoundation/Core (~> 1.7.5)
     - DTFoundation/DTAnimatedGIF (~> 1.7.5)
     - DTFoundation/DTHTMLParser (~> 1.7.5)
     - DTFoundation/UIKit (~> 1.7.5)
-  - DTFoundation/Core (1.7.13)
-  - DTFoundation/DTAnimatedGIF (1.7.13)
-  - DTFoundation/DTHTMLParser (1.7.13):
+  - DTFoundation/Core (1.7.14)
+  - DTFoundation/DTAnimatedGIF (1.7.14)
+  - DTFoundation/DTHTMLParser (1.7.14):
     - DTFoundation/Core
-  - DTFoundation/UIKit (1.7.13):
+  - DTFoundation/UIKit (1.7.14):
     - DTFoundation/Core
   - Embassy (4.0.8)
   - HTMLSpecialCharacters (1.3.6)
   - LicensesViewController (0.7.0)
-  - MaterialComponents/ActivityIndicator (85.8.0):
+  - MaterialComponents/ActivityIndicator (91.1.0):
     - MaterialComponents/Palettes
     - MaterialComponents/private/Application
     - MDFInternationalization
     - MotionAnimator (~> 2.0)
-  - MaterialComponents/AnimationTiming (85.8.0)
-  - MaterialComponents/Ink (85.8.0):
+  - MaterialComponents/AnimationTiming (91.1.0)
+  - MaterialComponents/Elevation (91.1.0):
+    - MaterialComponents/private/Color
     - MaterialComponents/private/Math
-  - MaterialComponents/Palettes (85.8.0)
-  - MaterialComponents/private/Application (85.8.0)
-  - MaterialComponents/private/Math (85.8.0)
-  - MaterialComponents/ProgressView (85.8.0):
+  - MaterialComponents/Ink (91.1.0):
+    - MaterialComponents/private/Color
+    - MaterialComponents/private/Math
+  - MaterialComponents/Palettes (91.1.0)
+  - MaterialComponents/private/Application (91.1.0)
+  - MaterialComponents/private/Color (91.1.0)
+  - MaterialComponents/private/Math (91.1.0)
+  - MaterialComponents/ProgressView (91.1.0):
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
     - MDFInternationalization
     - MotionAnimator (~> 2.1)
-  - MaterialComponents/Ripple (85.8.0):
+  - MaterialComponents/Ripple (91.1.0):
     - MaterialComponents/AnimationTiming
+    - MaterialComponents/private/Color
     - MaterialComponents/private/Math
-  - MaterialComponents/ShadowElevations (85.8.0)
-  - MaterialComponents/ShadowLayer (85.8.0):
+  - MaterialComponents/ShadowElevations (91.1.0)
+  - MaterialComponents/ShadowLayer (91.1.0):
     - MaterialComponents/ShadowElevations
-  - MaterialComponents/Tabs (85.8.0):
+  - MaterialComponents/Tabs (91.1.0):
     - MaterialComponents/AnimationTiming
+    - MaterialComponents/Elevation
     - MaterialComponents/Ink
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
@@ -55,7 +62,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFInternationalization
-  - MaterialComponents/Typography (85.8.0):
+  - MaterialComponents/Typography (91.1.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/Math
   - MDFInternationalization (2.0.0)
@@ -67,29 +74,29 @@ PODS:
   - MTColorDistance (0.0.3)
   - OpalImagePicker (2.1.0)
   - QuickLayout (3.0.0)
-  - Realm (3.17.1):
-    - Realm/Headers (= 3.17.1)
-  - Realm/Headers (3.17.1)
-  - RealmSwift (3.17.1):
-    - Realm (= 3.17.1)
+  - Realm (3.18.0):
+    - Realm/Headers (= 3.18.0)
+  - Realm/Headers (3.18.0)
+  - RealmSwift (3.18.0):
+    - Realm (= 3.18.0)
   - reddift (2.0.3):
     - HTMLSpecialCharacters
     - MiniKeychain
   - RLBAlertsPickers (1.1.1)
   - SDCAlertView (10.0)
-  - SDWebImage (5.0.6):
-    - SDWebImage/Core (= 5.0.6)
-  - SDWebImage/Core (5.0.6)
+  - SDWebImage (5.1.1):
+    - SDWebImage/Core (= 5.1.1)
+  - SDWebImage/Core (5.1.1)
   - SloppySwiper (0.6)
   - Starscream (3.0.6)
   - SubtleVolume (1.1.0)
   - SwiftEntryKit (1.0.1):
     - QuickLayout (= 3.0.0)
   - SwiftLinkPreview (3.0.1)
-  - SwiftLint (0.34.0)
+  - SwiftLint (0.35.0)
   - SwiftSpreadsheet (1.2.1)
   - SwiftyJSON (5.0.0)
-  - Then (2.5.0)
+  - Then (2.6.0)
   - YYText (1.0.7)
 
 DEPENDENCIES:
@@ -170,7 +177,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DTCoreText:
-    :commit: 7746c601985b06bade170a8f5f4bcafbb6f0a9c8
+    :commit: 5412f51dddad970029a46a26b70c7cf7aff2ef7e
     :git: https://github.com/Cocoanetics/DTCoreText
   MKColorPicker:
     :commit: e76cd225ff60f12f8ec0052e39e5e307a32c0762
@@ -192,16 +199,16 @@ CHECKOUT OPTIONS:
     :git: https://github.com/ccrama/SwiftEntryKit
 
 SPEC CHECKSUMS:
-  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
+  Alamofire: afc3e7c6db61476cb45cdd23fed06bad03bbc321
   Anchorage: a187da0bc9b07440637d42c8744b8c82a4490295
   BadgeSwift: 5cfacfad916d85e2f68d93dbb9ade4e9555903da
   BiometricAuthentication: e39b1a55040d679d5dbc4fa90d76e067c432de7f
-  DTCoreText: ad5135357a0e792f735970ed67d3ecda8b602d3d
-  DTFoundation: f03be9fd786f11e505bb8fc44e2a3732bf0917df
+  DTCoreText: 67023bb51b26711d5f640c851f4845aea14c24c9
+  DTFoundation: 25aa19bb7c6e225b1dfae195604fb8cf1da0ab4c
   Embassy: fe6a3f8dd2d705881c172dcb144fb97b9408f4cd
   HTMLSpecialCharacters: edc707cc4bcdc92eb3b9551de8cff94c1e6f9a19
   LicensesViewController: 2f7bba13b3cec7516d4990e41df297720fdbaaab
-  MaterialComponents: d3c6936b52687041650c99d2298d16fb2767f97a
+  MaterialComponents: 5225abc67ef52773d10a74583b8e662c032766ff
   MDFInternationalization: 010097556d6b09d2c4ea38e0820ea6d37be6a314
   MiniKeychain: 5d424fcd50fb8ab4cc946db2c3415dc391ffffdc
   MKColorPicker: 8998b2ab977e4f240fdf254db27a18b810da3cfc
@@ -210,23 +217,23 @@ SPEC CHECKSUMS:
   MTColorDistance: 5ab8708eb88bc22d4d88e309d09eb912f3a6e27b
   OpalImagePicker: 40e9d4c27018538a704d8da34b2ff3a2a54a3dc8
   QuickLayout: 07b45a72b10083fee3f095990cfed1c1e7b27f0a
-  Realm: c204f1a890f07dea43b14132a6aad118c054b8f2
-  RealmSwift: 4d3c9233544b9cd08a8913e0872b9038eb99b054
+  Realm: 7b3d04740facf45e958a514b466a32b04f1113d6
+  RealmSwift: c817b5f374668cf08f649afb05f55d92a787649c
   reddift: 42af05f3d2db6315cdf144be9256de36e86a523a
-  RLBAlertsPickers: c93e83c13526a5840b67eb52f702d3f83eeaac6a
+  RLBAlertsPickers: e8d2b6dd7d97d32e1f940a6b3bd3e8913bd6ad90
   SDCAlertView: 5fbc48cae6d7bf9781097e3f27883924ef3b922c
-  SDWebImage: 920f1a2ff1ca8296ad34f6e0510a1ef1d70ac965
+  SDWebImage: 96d7f03415ccb28d299d765f93557ff8a617abd8
   SloppySwiper: 37e38f6da8df5c805914c6f32ec6ec8da63abe7c
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SubtleVolume: 101038d203018736bcd1df3ac95bcc0f6b8640ce
-  SwiftEntryKit: ef368c3e6f47b79806f47376194a50489736ef68
+  SwiftEntryKit: b56480d9a03c30b3fe92f0ab9c2305530a138fe6
   SwiftLinkPreview: 7524438c43bf63a5041615713777c3d8f19a9a31
-  SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
+  SwiftLint: 5553187048b900c91aa03552807681bb6b027846
   SwiftSpreadsheet: b3dc6d89bd5fd18f38fe88c29898fbc481660a04
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  Then: 0157115e883545c77967b452fe74a1d25fb796e1
+  Then: 90cd104fd951cec1980a03f57704ad8f784d4d79
   YYText: 5c461d709e24d55a182d1441c41dc639a18a4849
 
-PODFILE CHECKSUM: 27236275aabf0857d445e4614b701856f7c13914
+PODFILE CHECKSUM: 7150437bda8ddb804a9de3a9683747f649f69ee3
 
 COCOAPODS: 1.7.1

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -1469,17 +1469,19 @@
 					BE20851C21588F3A00D8F33C = {
 						CreatedOnToolsVersion = 10.0;
 						DevelopmentTeam = FTT89576VQ;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					BE257A6A21F64AA30082A47E = {
 						CreatedOnToolsVersion = 10.1;
 						DevelopmentTeam = FTT89576VQ;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					BE8FCA031E0C46090063B8EF = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = FTT89576VQ;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -1499,14 +1501,14 @@
 					BE8FCA171E0C46090063B8EF = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = FTT89576VQ;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						TestTargetID = BE8FCA031E0C46090063B8EF;
 					};
 					BE8FCA221E0C46090063B8EF = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = FTT89576VQ;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						TestTargetID = BE8FCA031E0C46090063B8EF;
 					};
@@ -2250,7 +2252,7 @@
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 4.3;
 			};
@@ -2276,7 +2278,7 @@
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 4.3;
 			};
@@ -2305,7 +2307,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_BASE_IDENTIFIER).Open-in-Slide";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2332,7 +2334,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_BASE_IDENTIFIER).Open-in-Slide";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2486,7 +2488,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				"SWIFT_OPTIMIZATION_LEVEL[arch=*]" = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2521,7 +2523,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Slide for Reddit/Slide for Reddit-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -2537,7 +2539,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Slide for Reddit.app/Slide for Reddit";
 			};
 			name = Debug;
@@ -2554,7 +2556,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Slide for Reddit.app/Slide for Reddit";
 			};
 			name = Release;
@@ -2570,7 +2572,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = "Slide for Reddit";
 			};
 			name = Debug;
@@ -2586,7 +2588,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = "Slide for Reddit";
 			};
 			name = Release;

--- a/Slide for Reddit/AccountController.swift
+++ b/Slide for Reddit/AccountController.swift
@@ -46,7 +46,7 @@ class AccountController {
             try LocalKeystore.removeToken(of: name)
             try OAuth2TokenRepository.removeToken(of: name)
 
-            names.remove(at: names.index(of: name)!)
+            names.remove(at: names.firstIndex(of: name)!)
             UserDefaults.standard.set(name, forKey: "GUEST")
             UserDefaults.standard.synchronize()
 

--- a/Slide for Reddit/ActionStates.swift
+++ b/Slide for Reddit/ActionStates.swift
@@ -35,15 +35,15 @@ class ActionStates {
         }
         let fullname = s.getId()
         
-        if let index = upVotedFullnames.index(of: fullname) {
+        if let index = upVotedFullnames.firstIndex(of: fullname) {
             upVotedFullnames.remove(at: index)
         }
         
-        if let index = downVotedFullnames.index(of: fullname) {
+        if let index = downVotedFullnames.firstIndex(of: fullname) {
             downVotedFullnames.remove(at: index)
         }
         
-        if let index = unvotedFullnames.index(of: fullname) {
+        if let index = unvotedFullnames.firstIndex(of: fullname) {
             unvotedFullnames.remove(at: index)
         }
         
@@ -69,7 +69,7 @@ class ActionStates {
     
     static func setRead(s: RMessage, read: Bool) {
         let fullname = s.getId()
-        if let index = savedFullnames.index(of: fullname) {
+        if let index = savedFullnames.firstIndex(of: fullname) {
             savedFullnames.remove(at: index)
         }
         
@@ -95,7 +95,7 @@ class ActionStates {
             HapticUtility.hapticActionStrong()
         }
         let fullname = s.getId()
-        if let index = savedFullnames.index(of: fullname) {
+        if let index = savedFullnames.firstIndex(of: fullname) {
             savedFullnames.remove(at: index)
         }
         
@@ -125,15 +125,15 @@ class ActionStates {
         }
         let fullname = s.getId()
         
-        if let index = upVotedFullnames.index(of: fullname) {
+        if let index = upVotedFullnames.firstIndex(of: fullname) {
             upVotedFullnames.remove(at: index)
         }
         
-        if let index = downVotedFullnames.index(of: fullname) {
+        if let index = downVotedFullnames.firstIndex(of: fullname) {
             downVotedFullnames.remove(at: index)
         }
         
-        if let index = unvotedFullnames.index(of: fullname) {
+        if let index = unvotedFullnames.firstIndex(of: fullname) {
             unvotedFullnames.remove(at: index)
         }
         
@@ -164,7 +164,7 @@ class ActionStates {
             HapticUtility.hapticActionStrong()
         }
         let fullname = s.getId()
-        if let index = savedFullnames.index(of: fullname) {
+        if let index = savedFullnames.firstIndex(of: fullname) {
             savedFullnames.remove(at: index)
         }
         
@@ -194,15 +194,15 @@ class ActionStates {
         }
         let fullname = s.getId()
         
-        if let index = upVotedFullnames.index(of: fullname) {
+        if let index = upVotedFullnames.firstIndex(of: fullname) {
             upVotedFullnames.remove(at: index)
         }
         
-        if let index = downVotedFullnames.index(of: fullname) {
+        if let index = downVotedFullnames.firstIndex(of: fullname) {
             downVotedFullnames.remove(at: index)
         }
         
-        if let index = unvotedFullnames.index(of: fullname) {
+        if let index = unvotedFullnames.firstIndex(of: fullname) {
             unvotedFullnames.remove(at: index)
         }
         
@@ -231,7 +231,7 @@ class ActionStates {
             HapticUtility.hapticActionStrong()
         }
         let fullname = s.getId()
-        if let index = savedFullnames.index(of: fullname) {
+        if let index = savedFullnames.firstIndex(of: fullname) {
             savedFullnames.remove(at: index)
         }
         

--- a/Slide for Reddit/AlbumViewController.swift
+++ b/Slide for Reddit/AlbumViewController.swift
@@ -154,7 +154,7 @@ class AlbumViewController: SwipeDownModalVC, UIPageViewControllerDataSource, UIP
                                             direction: .forward,
                                             animated: true,
                                             completion: nil)
-                    self.navItem?.title = "\(self.urlStringKeys.index(of: ((self.viewControllers!.first! as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!)! + 1)/\(self.urlStringKeys.count)"
+                    self.navItem?.title = "\(self.urlStringKeys.firstIndex(of: ((self.viewControllers!.first! as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!)! + 1)/\(self.urlStringKeys.count)"
                     let overview = UIButton.init(type: .custom)
                     overview.setImage(UIImage(sfString: SFSymbol.squareGrid2x2Fill, overrideString: "grid")?.navIcon(true), for: UIControl.State.normal)
                     overview.addTarget(self, action: #selector(self.overview(_:)), for: UIControl.Event.touchUpInside)
@@ -330,12 +330,12 @@ class AlbumViewController: SwipeDownModalVC, UIPageViewControllerDataSource, UIP
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating: Bool, previousViewControllers: [UIViewController], transitionCompleted: Bool) {
-        navItem?.title = "\(urlStringKeys.index(of: ((viewControllers!.first! as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!)! + 1)/\(urlStringKeys.count)"
+        navItem?.title = "\(urlStringKeys.firstIndex(of: ((viewControllers!.first! as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!)! + 1)/\(urlStringKeys.count)"
     }
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = urlStringKeys.index(of: ((viewController as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!) else {
+        guard let viewControllerIndex = urlStringKeys.firstIndex(of: ((viewController as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!) else {
             return nil
         }
         
@@ -354,7 +354,7 @@ class AlbumViewController: SwipeDownModalVC, UIPageViewControllerDataSource, UIP
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = urlStringKeys.index(of: ((viewController as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!) else {
+        guard let viewControllerIndex = urlStringKeys.firstIndex(of: ((viewController as! ModalMediaViewController).embeddedVC.data.baseURL?.absoluteString)!) else {
             return nil
         }
         

--- a/Slide for Reddit/CacheSettings.swift
+++ b/Slide for Reddit/CacheSettings.swift
@@ -124,7 +124,7 @@ class CacheSettings: BubbleSettingTableViewController {
         } else if changed == cacheContentSwitch {
             //todo this setting
         } else if !changed.isOn {
-            selected.remove(at: selected.index(of: changed.accessibilityIdentifier!)!)
+            selected.remove(at: selected.firstIndex(of: changed.accessibilityIdentifier!)!)
             Subscriptions.setOffline(subs: selected) {
             }
         } else {

--- a/Slide for Reddit/CollectionsViewController.swift
+++ b/Slide for Reddit/CollectionsViewController.swift
@@ -145,7 +145,7 @@ class CollectionsViewController: UIPageViewController, UIPageViewControllerDataS
         guard completed else {
             return
         }
-        let page = vCs.index(of: self.viewControllers!.first!)
+        let page = vCs.firstIndex(of: self.viewControllers!.first!)
 
         if !selected {
             tabBar.setSelectedItem(tabBar.items[page!], animated: true)
@@ -180,7 +180,7 @@ class CollectionsViewController: UIPageViewController, UIPageViewControllerDataS
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -199,7 +199,7 @@ class CollectionsViewController: UIPageViewController, UIPageViewControllerDataS
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -222,8 +222,8 @@ class CollectionsViewController: UIPageViewController, UIPageViewControllerDataS
 extension CollectionsViewController: MDCTabBarDelegate {
 
     func tabBar(_ tabBar: MDCTabBar, didSelect item: UITabBarItem) {
-        let firstViewController = vCs[tabBar.items.index(of: item)!]
-        currentIndex = tabBar.items.index(of: item)!
+        let firstViewController = vCs[tabBar.items.firstIndex(of: item)!]
+        currentIndex = tabBar.items.firstIndex(of: item)!
         setViewControllers([firstViewController],
                            direction: .forward,
                            animated: false,

--- a/Slide for Reddit/CommentDepthCell.swift
+++ b/Slide for Reddit/CommentDepthCell.swift
@@ -1086,7 +1086,7 @@ class CommentDepthCell: MarginedTableViewCell, UIViewControllerPreviewingDelegat
                     case .success:
                         self.parent!.approved.append(self.comment!.id)
                         if self.parent!.removed.contains(self.comment!.id) {
-                            self.parent!.removed.remove(at: self.parent!.removed.index(of: self.comment!.id)!)
+                            self.parent!.removed.remove(at: self.parent!.removed.firstIndex(of: self.comment!.id)!)
                         }
                         DispatchQueue.main.async {
                             self.parent!.tableView.reloadData()
@@ -1160,7 +1160,7 @@ class CommentDepthCell: MarginedTableViewCell, UIViewControllerPreviewingDelegat
                     case .success:
                         self.parent!.removed.append(self.comment!.id)
                         if self.parent!.approved.contains(self.comment!.id) {
-                            self.parent!.approved.remove(at: self.parent!.approved.index(of: self.comment!.id)!)
+                            self.parent!.approved.remove(at: self.parent!.approved.firstIndex(of: self.comment!.id)!)
                         }
                         DispatchQueue.main.async {
                             self.parent!.tableView.reloadData()

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -2076,7 +2076,7 @@ class CommentViewController: MediaTableViewController, TTTAttributedCellDelegate
     func walkTree(n: String) -> [String] {
         var toReturn: [String] = []
         if content[n] is RComment {
-            let bounds = comments.index(where: { ($0 == n) })! + 1
+            let bounds = comments.firstIndex(where: { ($0 == n) })! + 1
             let parentDepth = (cDepth[n] ?? 0)
             for obj in stride(from: bounds, to: comments.count, by: 1) {
                 if (cDepth[comments[obj]] ?? 0) > parentDepth {
@@ -2092,7 +2092,7 @@ class CommentViewController: MediaTableViewController, TTTAttributedCellDelegate
     func walkTreeFlat(n: String) -> [String] {
         var toReturn: [String] = []
         if content[n] is RComment {
-            let bounds = comments.index(where: { ($0 == n) })! + 1
+            let bounds = comments.firstIndex(where: { ($0 == n) })! + 1
             let parentDepth = (cDepth[n] ?? 0)
             for obj in stride(from: bounds, to: comments.count, by: 1) {
                 let depth = (cDepth[comments[obj]] ?? 0)
@@ -2110,7 +2110,7 @@ class CommentViewController: MediaTableViewController, TTTAttributedCellDelegate
         var toReturn: [String] = []
         toReturn.append(n)
         if content[n] is RComment {
-            let bounds = comments.index(where: { $0 == n })! + 1
+            let bounds = comments.firstIndex(where: { $0 == n })! + 1
             let parentDepth = (cDepth[n] ?? 0)
             for obj in stride(from: bounds, to: comments.count, by: 1) {
                 let currentDepth = cDepth[comments[obj]] ?? 0
@@ -2616,7 +2616,7 @@ override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexP
                             cell.showMenu(nil)
                         } else if cell.isCollapsed {
                             if hiddenPersons.contains((id)) {
-                                hiddenPersons.remove(at: hiddenPersons.index(of: id)!)
+                                hiddenPersons.remove(at: hiddenPersons.firstIndex(of: id)!)
                             }
                             if let oldHeight = oldHeights[id] {
                                 UIView.animate(withDuration: 0.25, delay: 0, options: UIView.AnimationOptions.curveEaseInOut, animations: {
@@ -2649,7 +2649,7 @@ override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexP
                         }
                     } else {
                         if hiddenPersons.contains((id)) && childNumber > 0 {
-                            hiddenPersons.remove(at: hiddenPersons.index(of: id)!)
+                            hiddenPersons.remove(at: hiddenPersons.firstIndex(of: id)!)
                             if let oldHeight = oldHeights[id] {
                                 UIView.animate(withDuration: 0.25, delay: 0, options: UIView.AnimationOptions.curveEaseInOut, animations: {
                                     cell.contentView.frame = CGRect(x: 0, y: 0, width: cell.contentView.frame.size.width, height: oldHeight)

--- a/Slide for Reddit/Drafts.swift
+++ b/Slide for Reddit/Drafts.swift
@@ -32,7 +32,7 @@ class Drafts {
     }
     
     public static func deleteDraft(s: String) {
-        drafts.remove(at: drafts.index(of: s as NSString)!)
+        drafts.remove(at: drafts.firstIndex(of: s as NSString)!)
         saveAndUpdate()
     }
     

--- a/Slide for Reddit/InboxViewController.swift
+++ b/Slide for Reddit/InboxViewController.swift
@@ -185,7 +185,7 @@ class InboxViewController: UIPageViewController, UIPageViewControllerDataSource,
         guard completed else {
             return
         }
-        let page = vCs.index(of: self.viewControllers!.first!)
+        let page = vCs.firstIndex(of: self.viewControllers!.first!)
 
         if !selected {
             tabBar.setSelectedItem(tabBar.items[page!], animated: true)
@@ -220,7 +220,7 @@ class InboxViewController: UIPageViewController, UIPageViewControllerDataSource,
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -239,7 +239,7 @@ class InboxViewController: UIPageViewController, UIPageViewControllerDataSource,
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -262,8 +262,8 @@ class InboxViewController: UIPageViewController, UIPageViewControllerDataSource,
 extension InboxViewController: MDCTabBarDelegate {
 
     func tabBar(_ tabBar: MDCTabBar, didSelect item: UITabBarItem) {
-        let firstViewController = vCs[tabBar.items.index(of: item)!]
-        currentIndex = tabBar.items.index(of: item)!
+        let firstViewController = vCs[tabBar.items.firstIndex(of: item)!]
+        currentIndex = tabBar.items.firstIndex(of: item)!
         setViewControllers([firstViewController],
                            direction: .forward,
                            animated: false,

--- a/Slide for Reddit/MainViewController.swift
+++ b/Slide for Reddit/MainViewController.swift
@@ -391,7 +391,7 @@ class MainViewController: ColorMuxPagingViewController, UINavigationControllerDe
     func goToSubreddit(subreddit: String) {
         menuNav?.dismiss(animated: true) {
             if self.finalSubs.contains(subreddit) {
-                let index = self.finalSubs.index(of: subreddit)
+                let index = self.finalSubs.firstIndex(of: subreddit)
                 if index == nil {
                     return
                 }
@@ -400,7 +400,7 @@ class MainViewController: ColorMuxPagingViewController, UINavigationControllerDe
                 
                 if SettingValues.subredditBar && !SettingValues.reduceColor {
                     self.color1 = ColorUtil.baseColor
-                    self.color2 = ColorUtil.getColorForSub(sub: (firstViewController as! SingleSubredditViewController).sub)
+                    self.color2 = ColorUtil.getColorForSub(sub: (firstViewController ).sub)
                 } else {
                     self.color1 = ColorUtil.theme.backgroundColor
                     self.color2 = ColorUtil.theme.backgroundColor
@@ -788,7 +788,7 @@ class MainViewController: ColorMuxPagingViewController, UINavigationControllerDe
         
         tabBar.tintColor = ColorUtil.accentColorForSub(sub: vc.sub)
         if !selected {
-            let page = finalSubs.index(of: (self.viewControllers!.first as! SingleSubredditViewController).sub)
+            let page = finalSubs.firstIndex(of: (self.viewControllers!.first as! SingleSubredditViewController).sub)
             if !tabBar.items.isEmpty {
                 tabBar.setSelectedItem(tabBar.items[page!], animated: true)
             }
@@ -1143,7 +1143,7 @@ extension MainViewController: UIPageViewControllerDataSource {
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        var index = finalSubs.index(of: (viewController as! SingleSubredditViewController).sub)
+        var index = finalSubs.firstIndex(of: (viewController as! SingleSubredditViewController).sub)
         if let vc = viewController as? SingleSubredditViewController {
             index = finalSubs.firstIndex(of: vc.sub)
         }
@@ -1166,7 +1166,7 @@ extension MainViewController: UIPageViewControllerDataSource {
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = finalSubs.index(of: (viewController as! SingleSubredditViewController).sub) else {
+        guard let viewControllerIndex = finalSubs.firstIndex(of: (viewController as! SingleSubredditViewController).sub) else {
             return nil
         }
         
@@ -1188,7 +1188,7 @@ extension MainViewController: UIPageViewControllerDataSource {
 
 extension MainViewController: UIPageViewControllerDelegate {
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        let page = finalSubs.index(of: (self.viewControllers!.first as! SingleSubredditViewController).sub)
+        let page = finalSubs.firstIndex(of: (self.viewControllers!.first as! SingleSubredditViewController).sub)
         //        let page = tabBar.items.index(of: tabBar.selectedItem!)
         // TODO: Crashes here
         guard page != nil else {
@@ -1292,14 +1292,14 @@ class IndicatorTemplate: NSObject, MDCTabBarIndicatorTemplate {
 extension MainViewController: MDCTabBarDelegate {
     func tabBar(_ tabBar: MDCTabBar, didSelect item: UITabBarItem) {
         selected = true
-        let firstViewController = SingleSubredditViewController(subName: finalSubs[tabBar.items.index(of: item)!], parent: self)
+        let firstViewController = SingleSubredditViewController(subName: finalSubs[tabBar.items.firstIndex(of: item)!], parent: self)
 
         setViewControllers([firstViewController],
                            direction: .forward,
                            animated: false,
                            completion: nil)
         
-        self.doCurrentPage(tabBar.items.index(of: item)!)
+        self.doCurrentPage(tabBar.items.firstIndex(of: item)!)
     }
 }
 

--- a/Slide for Reddit/MediaTableViewController.swift
+++ b/Slide for Reddit/MediaTableViewController.swift
@@ -135,7 +135,7 @@ class MediaTableViewController: UITableViewController, MediaVCDelegate, UIViewCo
 
         if shouldTruncate(url: contentUrl!) {
             let content = contentUrl?.absoluteString
-            contentUrl = URL.init(string: (String(content?[..<content!.index(of: ".")!] ?? "")))
+            contentUrl = URL.init(string: (String(content?[..<content!.firstIndex(of: ".")!] ?? "")))
         }
 
         let type = ContentType.getContentType(baseUrl: contentUrl)

--- a/Slide for Reddit/MediaViewController.swift
+++ b/Slide for Reddit/MediaViewController.swift
@@ -144,7 +144,7 @@ class MediaViewController: UIViewController, MediaVCDelegate, UIPopoverPresentat
         contentUrl = baseUrl.absoluteString.startsWith("//") ? URL(string: "https:\(baseUrl.absoluteString)") ?? baseUrl : baseUrl
         if shouldTruncate(url: contentUrl!) {
             let content = contentUrl?.absoluteString
-            contentUrl = URL.init(string: (String(content?[..<content!.index(of: ".")!] ?? "")))
+            contentUrl = URL.init(string: (String(content?[..<content!.firstIndex(of: ".")!] ?? "")))
         }
         let type = ContentType.getContentType(baseUrl: contentUrl)
 

--- a/Slide for Reddit/ModerationViewController.swift
+++ b/Slide for Reddit/ModerationViewController.swift
@@ -174,7 +174,7 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
         guard completed else {
             return
         }
-        let page = vCs.index(of: self.viewControllers!.first!)
+        let page = vCs.firstIndex(of: self.viewControllers!.first!)
 
         if !selected {
             tabBar.setSelectedItem(tabBar.items[page! ], animated: true)
@@ -189,7 +189,7 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -208,7 +208,7 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
 
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
 
@@ -232,7 +232,7 @@ extension ModerationViewController: MDCTabBarDelegate {
 
     func tabBar(_ tabBar: MDCTabBar, didSelect item: UITabBarItem) {
         selected = true
-        let firstViewController = vCs[tabBar.items.index(of: item)!]
+        let firstViewController = vCs[tabBar.items.firstIndex(of: item)!]
 
         setViewControllers([firstViewController],
                 direction: .forward,

--- a/Slide for Reddit/PostActions.swift
+++ b/Slide for Reddit/PostActions.swift
@@ -274,7 +274,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.approved.append(id)
                     if CachedTitle.removed.contains(id) {
-                        CachedTitle.removed.remove(at: CachedTitle.removed.index(of: id)!)
+                        CachedTitle.removed.remove(at: CachedTitle.removed.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         BannerUtil.makeBanner(text: "Submission \(!set ? "un" : "")locked!", color: GMColor.green500Color(), seconds: 3, context: cell.parentViewController)
@@ -301,7 +301,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.approved.append(id)
                     if CachedTitle.removed.contains(id) {
-                        CachedTitle.removed.remove(at: CachedTitle.removed.index(of: id)!)
+                        CachedTitle.removed.remove(at: CachedTitle.removed.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         BannerUtil.makeBanner(text: "Spoiler tag set!", color: GMColor.green500Color(), seconds: 3, context: cell.parentViewController)
@@ -328,7 +328,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.approved.append(id)
                     if CachedTitle.removed.contains(id) {
-                        CachedTitle.removed.remove(at: CachedTitle.removed.index(of: id)!)
+                        CachedTitle.removed.remove(at: CachedTitle.removed.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         BannerUtil.makeBanner(text: "NSFW tag set!", color: GMColor.green500Color(), seconds: 3, context: cell.parentViewController)
@@ -355,7 +355,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.approved.append(id)
                     if CachedTitle.removed.contains(id) {
-                        CachedTitle.removed.remove(at: CachedTitle.removed.index(of: id)!)
+                        CachedTitle.removed.remove(at: CachedTitle.removed.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         cell.refreshLink(cell.link!, np: false)
@@ -463,7 +463,7 @@ class PostActions: NSObject {
         
         for reason in reasons {
             sheet.addAction(title: reason, icon: nil) {
-                let index = reasons.index(of: reason) ?? 0
+                let index = reasons.firstIndex(of: reason) ?? 0
                 if index == 0 {
                     modRemoveReason(cell, reason: "")
                 } else if index == 1 {
@@ -492,7 +492,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.removed.append(id)
                     if CachedTitle.approved.contains(id) {
-                        CachedTitle.approved.remove(at: CachedTitle.approved.index(of: id)!)
+                        CachedTitle.approved.remove(at: CachedTitle.approved.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         BannerUtil.makeBanner(text: "Submission removed!", color: GMColor.green500Color(), seconds: 3, context: cell.parentViewController)
@@ -518,7 +518,7 @@ class PostActions: NSObject {
                 case .success:
                     CachedTitle.removed.append(id)
                     if CachedTitle.approved.contains(id) {
-                        CachedTitle.approved.remove(at: CachedTitle.approved.index(of: id)!)
+                        CachedTitle.approved.remove(at: CachedTitle.approved.firstIndex(of: id)!)
                     }
                     DispatchQueue.main.async {
                         BannerUtil.makeBanner(text: "Submission removed!", color: GMColor.green500Color(), seconds: 3, context: cell.parentViewController)

--- a/Slide for Reddit/ProfileViewController.swift
+++ b/Slide for Reddit/ProfileViewController.swift
@@ -280,7 +280,7 @@ class ProfileViewController: UIPageViewController, UIPageViewControllerDataSourc
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
         
@@ -299,7 +299,7 @@ class ProfileViewController: UIPageViewController, UIPageViewControllerDataSourc
     
     func pageViewController(_ pageViewController: UIPageViewController,
                             viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let viewControllerIndex = vCs.index(of: viewController) else {
+        guard let viewControllerIndex = vCs.firstIndex(of: viewController) else {
             return nil
         }
         
@@ -324,7 +324,7 @@ class ProfileViewController: UIPageViewController, UIPageViewControllerDataSourc
     
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         guard completed else { return }
-        let page = vCs.index(of: self.viewControllers!.first!)
+        let page = vCs.firstIndex(of: self.viewControllers!.first!)
 
         tabBar.setSelectedItem(tabBar.items[page! ], animated: true)
         currentVc = self.viewControllers!.first!
@@ -371,8 +371,8 @@ extension ProfileViewController: MDCTabBarDelegate {
     
     func tabBar(_ tabBar: MDCTabBar, didSelect item: UITabBarItem) {
         selected = true
-        let firstViewController = vCs[tabBar.items.index(of: item)!]
-        currentIndex = tabBar.items.index(of: item)!
+        let firstViewController = vCs[tabBar.items.firstIndex(of: item)!]
+        currentIndex = tabBar.items.firstIndex(of: item)!
         currentVc = firstViewController
         
         let contentIndex = currentIndex - (friends ? 1 : 0)

--- a/Slide for Reddit/RemovalReasons.swift
+++ b/Slide for Reddit/RemovalReasons.swift
@@ -33,7 +33,7 @@ class RemovalReasons {
     }
     
     public static func deleteReason(s: String) {
-        reasons.remove(at: reasons.index(of: s as NSString)!)
+        reasons.remove(at: reasons.firstIndex(of: s as NSString)!)
         saveAndUpdate()
     }
     

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1957,7 +1957,7 @@ extension SingleSubredditViewController {
     @objc func hideAll(_ sender: AnyObject) {
         for submission in links {
             if History.getSeen(s: submission) {
-                let index = links.index(of: submission)!
+                let index = links.firstIndex(of: submission)!
                 links.remove(at: index)
             }
         }

--- a/Slide for Reddit/VideoMediaViewController.swift
+++ b/Slide for Reddit/VideoMediaViewController.swift
@@ -864,7 +864,7 @@ extension VideoMediaViewController {
                 return
             }
             guard let data = data,
-                let jsonObj = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? NSDictionary,
+                let jsonObj = ((try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? NSDictionary) as NSDictionary??),
                 let dict = jsonObj else {
                 failureBlock()
                 return


### PR DESCRIPTION
This migrates the Slide project to Swift 5, including the Apple Watch extension and Open with Slide.
Additionally I updated all pods since some may have received the Swift 5 migration as well
Any pods that haven't migrated appropriately I specified to only be built with 4.2 in the Podfile. Those are Embassy, HTMLSpecialCharacters, and Minikeychain. 

I'm surprised to say this is NOT dependent on the other PR I have to clean up all the warnings. Both build successfully independently. 

Real clean migration this time around.