### PR TITLE
refactor: restructure data in SettingsIcon class

### DIFF
--- a/Slide for Reddit/SettingsIcon.swift
+++ b/Slide for Reddit/SettingsIcon.swift
@@ -11,28 +11,28 @@ import reddift
 import UIKit
 
 class SettingsIcon: BubbleSettingTableViewController {
-    var iconSections = [
-        (id: "premium", title: "Premium icons", iconRows: [
-            (id: "retroapple", title: "Retro"),
-            (id: "tronteal", title: "Tron"),
-            (id: "pink", title: "Pink"),
-            (id: "black", title: "Black"),
+    let iconSections: [(id: String, title: String, iconRows: [(id: String, title: String)])] = [
+        ("premium", "Premium icons", [
+            ("retroapple", "Retro"),
+            ("tronteal", "Tron"),
+            ("pink", "Pink"),
+            ("black", "Black"),
         ]),
-        (id: "community", title: "Community icons", iconRows: [
-            (id: "cottoncandy", title: "Cotton Candy"),
-            (id: "outrun", title: "Outrun"),
-            (id: "stars", title: "Starry night u/TyShark"),
-            (id: "ghost", title: "Ghost"),
-            (id: "mint", title: "Mint u/Baselt95"),
+        ("community", "Community icons", [
+            ("cottoncandy", "Cotton Candy"),
+            ("outrun", "Outrun"),
+            ("stars", "Starry night u/TyShark"),
+            ("ghost", "Ghost"),
+            ("mint", "Mint u/Baselt95"),
         ]),
-        (id: "basic", title: "Basic icons", iconRows: [
-            (id: "red", title: "Red"),
-            (id: "default", title: "Standard"),
-            (id: "yellow", title: "Yellow"),
-            (id: "green", title: "Green"),
-            (id: "lightblue", title: "Light Blue"),
-            (id: "blue", title: "Blue"),
-            (id: "purple", title: "Purple"),
+        ("basic", "Basic icons", [
+            ("red", "Red"),
+            ("default", "Standard"),
+            ("yellow", "Yellow"),
+            ("green", "Green"),
+            ("lightblue", "Light Blue"),
+            ("blue", "Blue"),
+            ("purple", "Purple"),
         ]),
     ]
     

--- a/Slide for Reddit/SettingsIcon.swift
+++ b/Slide for Reddit/SettingsIcon.swift
@@ -21,16 +21,18 @@ class SettingsIcon: BubbleSettingTableViewController {
         (id: "community", title: "Community icons", iconRows: [
             (id: "cottoncandy", title: "Cotton Candy"),
             (id: "outrun", title: "Outrun"),
-            (id: "default", title: "Standard"),
             (id: "stars", title: "Starry night u/TyShark"),
             (id: "ghost", title: "Ghost"),
-            (id: "blue", title: "Blue"),
             (id: "mint", title: "Mint u/Baselt95"),
+        ]),
+        (id: "basic", title: "Basic icons", iconRows: [
+            (id: "red", title: "Red"),
+            (id: "default", title: "Standard"),
+            (id: "yellow", title: "Yellow"),
             (id: "green", title: "Green"),
             (id: "lightblue", title: "Light Blue"),
+            (id: "blue", title: "Blue"),
             (id: "purple", title: "Purple"),
-            (id: "red", title: "Red"),
-            (id: "yellow", title: "Yellow"),
         ]),
     ]
     

--- a/Slide for Reddit/SettingsIcon.swift
+++ b/Slide for Reddit/SettingsIcon.swift
@@ -11,13 +11,29 @@ import reddift
 import UIKit
 
 class SettingsIcon: BubbleSettingTableViewController {
+    var iconSections = [
+        (id: "premium", title: "Premium icons", iconRows: [
+            (id: "retroapple", title: "Retro"),
+            (id: "tronteal", title: "Tron"),
+            (id: "pink", title: "Pink"),
+            (id: "black", title: "Black"),
+        ]),
+        (id: "community", title: "Community icons", iconRows: [
+            (id: "cottoncandy", title: "Cotton Candy"),
+            (id: "outrun", title: "Outrun"),
+            (id: "default", title: "Standard"),
+            (id: "stars", title: "Starry night u/TyShark"),
+            (id: "ghost", title: "Ghost"),
+            (id: "blue", title: "Blue"),
+            (id: "mint", title: "Mint u/Baselt95"),
+            (id: "green", title: "Green"),
+            (id: "lightblue", title: "Light Blue"),
+            (id: "purple", title: "Purple"),
+            (id: "red", title: "Red"),
+            (id: "yellow", title: "Yellow"),
+        ]),
+    ]
     
-    var premium = ["retroapple", "tronteal", "pink", "black"]
-    var community = ["cottoncandy", "outrun", "default", "stars", "ghost", "blue", "mint", "green", "lightblue", "purple", "red", "yellow"]
-    
-    var premiumNames = ["Retro", "Tron", "Pink", "Black"]
-    var communityNames = ["Cotton Candy", "Outrun", "Standard", "Starry night u/TyShark", "Ghost", "Blue", "Mint u/Baselt95", "Green", "Light Blue", "Purple", "Red", "Yellow"]
-
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.register(IconCell.classForCoder(), forCellReuseIdentifier: "icon")
@@ -25,55 +41,45 @@ class SettingsIcon: BubbleSettingTableViewController {
     
     override func loadView() {
         super.loadView()
-        headers = ["Premium icons", "Community icons"]
-        self.view.backgroundColor = ColorUtil.theme.backgroundColor
-        // set the title
-        self.title = "App icon"
         
-        doChecks()
+        headers = iconSections.map({ $0.title })
+        self.view.backgroundColor = ColorUtil.theme.backgroundColor
+        self.title = "App icon"
+
         self.tableView.tableFooterView = UIView()
     }
     
-    func doChecks() {
-       
-       // TODO: - accessory view
-    }
-    
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return iconSections.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "icon") as! IconCell
+        let iconSection = iconSections[indexPath.section]
+        let iconRow = iconSection.iconRows[indexPath.row]
         
-        let title = indexPath.section == 0 ? premiumNames[indexPath.row] : communityNames[indexPath.row]
-        cell.title.text = title
+        cell.title.text = iconRow.title
+        cell.iconView.image = iconRow.id == "default"
+            ? UIImage(named: "AppIcon")
+            : UIImage(named: "ic_" + iconRow.id)
         
-        let isDefault = indexPath.row == 2 && indexPath.section == 1
-        
-        cell.iconView.image = isDefault ? UIImage(named: "AppIcon") : UIImage(named: "ic_" + (indexPath.section == 0 ? premium[indexPath.row] : community[indexPath.row]))
         return cell
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
         tableView.deselectRow(at: indexPath, animated: true)
-        let title = indexPath.section == 0 ? premium[indexPath.row] : community[indexPath.row]
-        let isDefault = indexPath.row == 2 && indexPath.section == 1
-
-        if indexPath.section == 1 || !VCPresenter.proDialogShown(feature: true, self) {
+        let iconSection = iconSections[indexPath.section]
+        let iconRow = iconSection.iconRows[indexPath.row]
+        
+        if iconSection.id != "premium" || !VCPresenter.proDialogShown(feature: true, self) {
             if #available(iOS 10.3, *) {
-                if isDefault {
-                    UIApplication.shared.setAlternateIconName(nil) { (error) in
-                        if let error = error {
-                            print("err: \(error)")
-                        }
-                    }
-                } else {
-                    UIApplication.shared.setAlternateIconName(title) { (error) in
-                        if let error = error {
-                            print("err: \(error)")
-                        }
+                UIApplication.shared.setAlternateIconName(
+                    iconRow.id == "default"
+                        ? nil
+                        : iconRow.id
+                ) { (error) in
+                    if let error = error {
+                        print("err: \(error)")
                     }
                 }
             }
@@ -81,13 +87,8 @@ class SettingsIcon: BubbleSettingTableViewController {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case 0: return premium.count    // section 0 has 2 rows
-        case 1: return community.count    // section 1 has 1 row
-        default: fatalError("Unknown number of sections")
-        }
+        return iconSections[section].iconRows.count
     }
-    
 }
 
 public class IconCell: InsetCell {
@@ -104,7 +105,7 @@ public class IconCell: InsetCell {
     
     func setupView() {
         self.contentView.addSubviews(title, iconView)
-        
+
         title.heightAnchor == 60
         title.rightAnchor == self.contentView.rightAnchor
         title.leftAnchor == self.iconView.rightAnchor + 8


### PR DESCRIPTION
This change didn't really change anything. At the most it makes it easily extendable later. In theory if you add another section it should just work (like if you broke the standard colors out from the actual community icons *wink*)

The current implementation would require knowledge of the new additions, while this change makes the data structured in a way that the view can just consume it without further code changes.
Since the data is static and (currently) only relevant here, there isn't really a point in making it unstructured and forcing a presentation layer of sorts to structure it for the view.

This is really just a personal change. I wasn't a fan of all the loosely coupled data that has is conceptually tightly coupled.

Additionally I **did** actually split the basic color icons into their own section away from the community icons. If that is false, and those icons ARE actually community made. I can move them back. See screenshot below:

<img width="506" alt="image" src="https://user-images.githubusercontent.com/5879831/65824859-a9227180-e23d-11e9-8bf6-d9d58a196d56.png">
