### PR TITLE
refactor: replace UIWebView usages with WKWebView

### DIFF
--- a/Slide for Reddit/LiveThreadUpdate.swift
+++ b/Slide for Reddit/LiveThreadUpdate.swift
@@ -10,13 +10,14 @@ import Anchorage
 import AudioToolbox
 import reddift
 import UIKit
+import WebKit
 import YYText
 
 class LiveThreadUpdate: UICollectionViewCell, UIGestureRecognizerDelegate {
     
     var title: YYLabel!
     var image = UIImageView()
-    var web = UIWebView()
+    var web = WKWebView()
     
     func attributedLabel(_ label: YYTextView!, didSelectLinkWith url: URL!) {
         parentViewController?.doShow(url: url, heroView: nil, heroVC: nil)
@@ -217,7 +218,7 @@ class LiveThreadUpdate: UICollectionViewCell, UIGestureRecognizerDelegate {
                     })
                 } else if let web = embeds["html"] as? String {
                     self.web.alpha = 1
-                    self.web.allowsInlineMediaPlayback = true
+                    self.web.configuration.allowsInlineMediaPlayback = true
                     self.web.loadHTMLString(web.decodeHTML().replacingOccurrences(of: "//", with: "https://"), baseURL: URL(string: "https://"))
                 }
                 let imageSize = CGSize.init(width: width, height: height)

--- a/Slide for Reddit/WebsiteViewController.swift
+++ b/Slide for Reddit/WebsiteViewController.swift
@@ -231,10 +231,6 @@ class WebsiteViewController: MediaViewController, WKNavigationDelegate {
         }
 
     }
-    
-    func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebView.NavigationType) -> Bool {
-        return request.url == nil || !(isAd(url: request.url!))
-    }
 
     func isAd(url: URL) -> Bool {
       let host = url.host


### PR DESCRIPTION
In conjunction with my other PR https://github.com/ccrama/Slide-iOS/pull/920 this will remove (I believe) the rest of the UIWebView calls in the app. I did not see any pods using UIWebView either.

Apple is doing a hard deprecation of UIWebView (as they should) where they will eventually (soon?) stop accepting apps using the API. If anything here seems off or if you know there are more usages I missed other than the YTPlayer, let me know.