### PR TITLE
chore: update from xcode 11.1

### DIFF
--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -1462,7 +1462,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = "Haptic Apps";
 				TargetAttributes = {
 					BE20851021588F3900D8F33C = {

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Share to Slide.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Share to Slide.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1110"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide Release.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Reddit Prod Test.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Reddit Prod Test.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Reddit.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Reddit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Just a small thing. Every time we (I?) update build settings this will just automatically happen. No reason to not do it. Just maintenance to update that the last XCode to update was 11.1