### PR TITLE
New swipe and gestures

### DIFF
--- a/Open in Slide/Info.plist
+++ b/Open in Slide/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Slide Screenshot Automation/Info.plist
+++ b/Slide Screenshot Automation/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 </dict>
 </plist>

--- a/Slide for Apple Watch Extension/Info.plist
+++ b/Slide for Apple Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Slide for Apple Watch/Info.plist
+++ b/Slide for Apple Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -2258,7 +2258,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = Slide_for_Apple_Watch_Extension;
@@ -2291,7 +2291,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = Slide_for_Apple_Watch_Extension;
@@ -2319,7 +2319,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide for Apple Watch Extension/Info.plist";
@@ -2348,7 +2348,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide for Apple Watch Extension/Info.plist";
@@ -2378,7 +2378,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Open in Slide/Info.plist";
@@ -2406,7 +2406,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Open in Slide/Info.plist";
@@ -2556,7 +2556,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = "Slide for Reddit/Info.plist";
@@ -2594,7 +2594,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_OPTIMIZATION_LEVEL = fast;
 				GCC_WARN_UNUSED_PARAMETER = YES;

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
@@ -65,8 +65,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Slide for Apple Watch Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Slide for Reddit">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -74,7 +76,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,8 +84,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Slide for Reddit">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -91,7 +95,16 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BE20851021588F3900D8F33C"
+            BuildableName = "Slide for Apple Watch.app"
+            BlueprintName = "Slide for Apple Watch"
+            ReferencedContainer = "container:Slide for Reddit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
@@ -65,10 +65,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Slide for Apple Watch Extension/PushNotificationPayload.apns">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Slide for Reddit">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -76,7 +74,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -84,10 +82,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Slide for Reddit">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -95,16 +91,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BE20851021588F3900D8F33C"
-            BuildableName = "Slide for Apple Watch.app"
-            BlueprintName = "Slide for Apple Watch"
-            ReferencedContainer = "container:Slide for Reddit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Slide for Reddit/AppDelegate.swift
+++ b/Slide for Reddit/AppDelegate.swift
@@ -577,7 +577,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let main = SplitMainViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
                 splitViewController.setViewController(SwipeForwardNavigationController(rootViewController: NavigationHomeViewController(controller: main)), for: .primary)
 
-                splitViewController.setViewController(main, for: .secondary)
+                splitViewController.setViewController(SwipeForwardNavigationController(rootViewController: main), for: .secondary)
                 window.rootViewController = splitViewController
                 self.window = window
                 window.makeKeyAndVisible()

--- a/Slide for Reddit/AppDelegate.swift
+++ b/Slide for Reddit/AppDelegate.swift
@@ -594,7 +594,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let main = SplitMainViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
                 splitViewController.setViewController(SwipeForwardNavigationController(rootViewController: NavigationHomeViewController(controller: main)), for: .primary)
 
-                splitViewController.setViewController(main, for: .supplementary)
+                splitViewController.setViewController(SwipeForwardNavigationController(rootViewController: main), for: .supplementary)
                 splitViewController.setViewController(PlaceholderViewController(), for: .secondary)
                 window.rootViewController = splitViewController
                 self.window = window

--- a/Slide for Reddit/ColorMuxPagingViewController.swift
+++ b/Slide for Reddit/ColorMuxPagingViewController.swift
@@ -24,6 +24,17 @@ public class ColorMuxPagingViewController: UIPageViewController, UIScrollViewDel
         }
     }
     
+    public func requireFailureOf(_ gesture: UIGestureRecognizer) {
+        for view in self.view.subviews {
+            if !(view is UICollectionView) {
+                if let scrollView = view as? UIScrollView {
+                    scrollView.delaysContentTouches = false
+                    gesture.require(toFail: scrollView.panGestureRecognizer)
+                }
+            }
+        }
+    }
+    
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let point = scrollView.contentOffset
 

--- a/Slide for Reddit/ColorMuxPagingViewController.swift
+++ b/Slide for Reddit/ColorMuxPagingViewController.swift
@@ -29,7 +29,7 @@ public class ColorMuxPagingViewController: UIPageViewController, UIScrollViewDel
             if !(view is UICollectionView) {
                 if let scrollView = view as? UIScrollView {
                     scrollView.delaysContentTouches = false
-                    gesture.require(toFail: scrollView.panGestureRecognizer)
+                    scrollView.panGestureRecognizer.require(toFail: gesture)
                 }
             }
         }

--- a/Slide for Reddit/CommentDepthCell.swift
+++ b/Slide for Reddit/CommentDepthCell.swift
@@ -433,7 +433,7 @@ class CommentDepthCell: MarginedTableViewCell, UIViewControllerPreviewingDelegat
             
             let currentTranslation = direction == -1 ? 0 - (self.contentView.bounds.size.width - posx - diff) : posx - diff
             self.contentView.frame.origin.x = posx - originalLocation
-
+            print(self.contentView.frame.origin.x)
             if (direction == -1 && SettingValues.commentActionLeftLeft == .NONE && SettingValues.commentActionLeftRight == .NONE) || (direction == 1 && SettingValues.commentActionRightRight == .NONE && SettingValues.commentActionRightLeft == .NONE) {
                 dragCancelled = true
                 sender.cancel()

--- a/Slide for Reddit/CommentDepthCell.swift
+++ b/Slide for Reddit/CommentDepthCell.swift
@@ -376,6 +376,7 @@ class CommentDepthCell: MarginedTableViewCell, UIViewControllerPreviewingDelegat
         }
 
         if dragCancelled {
+            sender.cancel()
             return
         }
         let xVelocity = sender.velocity(in: self).x

--- a/Slide for Reddit/CommentDepthCell.swift
+++ b/Slide for Reddit/CommentDepthCell.swift
@@ -965,6 +965,12 @@ class CommentDepthCell: MarginedTableViewCell, UIViewControllerPreviewingDelegat
             }
         }
     }
+    override func layoutSubviews() {
+        if typeImage != nil {
+            return
+        }
+        super.layoutSubviews()
+    }
     
     var replyDelegate: ReplyDelegate?
     @objc func reply(_ s: AnyObject) {

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -3203,7 +3203,6 @@ extension CommentViewController: UIGestureRecognizerDelegate {
         if recognizer.view != nil {
             let velocity = recognizer.velocity(in: recognizer.view!).x
             if (velocity < 0 && (SettingValues.commentActionLeftLeft == .NONE && SettingValues.commentActionLeftRight == .NONE) && translatingCell == nil) || (velocity > 0 && (SettingValues.commentActionRightLeft == .NONE && SettingValues.commentActionRightRight == .NONE) && translatingCell == nil) {
-                recognizer.cancel()
                 return
             }
         }
@@ -3212,7 +3211,6 @@ extension CommentViewController: UIGestureRecognizerDelegate {
             let point = recognizer.location(in: self.tableView)
             let indexpath = self.tableView.indexPathForRow(at: point)
             if indexpath == nil {
-                recognizer.cancel()
                 return
             }
 
@@ -3220,7 +3218,6 @@ extension CommentViewController: UIGestureRecognizerDelegate {
             for view in cell.commentBody.subviews {
                 let cellPoint = recognizer.location(in: view)
                 if (view is UIScrollView || view is CodeDisplayView || view is TableDisplayView) && view.bounds.contains(cellPoint) {
-                    recognizer.cancel()
                     return
                 }
             }

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -1309,7 +1309,9 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
         headerCell!.parentViewController = self
         headerCell!.aspectWidth = self.tableView.bounds.size.width
 
-        setupGestures()
+        if SettingValues.commentActionRightLeft != .NONE || SettingValues.commentActionRightRight != .NONE {
+            setupGestures()
+        }
         
         self.presentationController?.delegate = self
 

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -3165,7 +3165,8 @@ extension CommentViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = panGestureRecognizer.translation(in: tableView)
-            if translation.x >= 0 {
+            let velocity = panGestureRecognizer.velocity(in: tableView)
+            if translation.x >= 0 && abs(translation.y) < 1 && velocity.x > 120 {
                 return true
             }
             return false

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -1309,7 +1309,7 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
         headerCell!.parentViewController = self
         headerCell!.aspectWidth = self.tableView.bounds.size.width
 
-        if SettingValues.commentActionRightLeft != .NONE || SettingValues.commentActionRightRight != .NONE {
+        if SettingValues.commentActionLeftLeft != .NONE || SettingValues.commentActionLeftRight != .NONE {
             setupGestures()
         }
         

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -3140,6 +3140,7 @@ extension CommentViewController: UIGestureRecognizerDelegate {
         cellGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(panCell(_:)))
         cellGestureRecognizer.delegate = self
         tableView.addGestureRecognizer(cellGestureRecognizer)
+        cellGestureRecognizer.require(toFail: tableView.panGestureRecognizer)
         if let parent = parent as? ColorMuxPagingViewController {
             parent.requireFailureOf(cellGestureRecognizer)
         }

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -3147,6 +3147,11 @@ extension CommentViewController: UIGestureRecognizerDelegate {
     }
     
     func setupSwipeGesture() {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            if #available(iOS 14, *) {
+                return
+            }
+        }
         fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
         if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController, !swipeBackAdded {
             swipeBackAdded = true
@@ -3173,7 +3178,7 @@ extension CommentViewController: UIGestureRecognizerDelegate {
             let translation = panGestureRecognizer.translation(in: tableView)
             if panGestureRecognizer == cellGestureRecognizer {
                 if translation.x < 0 {
-                    if gestureRecognizer.location(in: tableView).x > tableView.frame.width * 0.60 {
+                    if gestureRecognizer.location(in: tableView).x > tableView.frame.width * 0.75 {
                         return true
                     }
                 }

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -3140,9 +3140,15 @@ extension CommentViewController: UIGestureRecognizerDelegate {
         cellGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(panCell(_:)))
         cellGestureRecognizer.delegate = self
         tableView.addGestureRecognizer(cellGestureRecognizer)
-        cellGestureRecognizer.require(toFail: tableView.panGestureRecognizer)
+        tableView.panGestureRecognizer.require(toFail: cellGestureRecognizer)
         if let parent = parent as? ColorMuxPagingViewController {
             parent.requireFailureOf(cellGestureRecognizer)
+        }
+        if let nav = self.navigationController as? SwipeForwardNavigationController {
+            nav.fullWidthBackGestureRecognizer.require(toFail: cellGestureRecognizer)
+            if let interactivePush = nav.interactivePushGestureRecognizer {
+                cellGestureRecognizer.require(toFail: interactivePush)
+            }
         }
     }
     
@@ -3184,7 +3190,7 @@ extension CommentViewController: UIGestureRecognizerDelegate {
                 }
                 return false
             }
-            if translation.x >= 0 {
+            if panGestureRecognizer == fullWidthBackGestureRecognizer && translation.x >= 0 {
                 return true
             }
             return false

--- a/Slide for Reddit/Info.plist
+++ b/Slide for Reddit/Info.plist
@@ -332,7 +332,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -761,12 +761,13 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     var tiConstraints = [NSLayoutConstraint]()
     
     @objc func handlePan(_ sender: UIPanGestureRecognizer) {
+        print("First \(self.contentView.frame.origin.x)")
         if sender.state == .began || typeImage == nil {
             dragCancelled = false
             direction = 0
-            originalLocation = sender.location(in: contentView).x
+            originalLocation = sender.location(in: self).x
             originalPos = self.contentView.frame.origin.x
-            diff = self.contentView.frame.width - originalLocation
+            diff = self.frame.width - originalLocation
             typeImage = UIImageView().then {
                 $0.accessibilityIdentifier = "Action type"
                 $0.layer.cornerRadius = 22.5
@@ -788,7 +789,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             if direction == -1 && self.contentView.frame.origin.x > originalPos {
                 if getFirstAction(left: false) != .NONE {
                     direction = 0
-                    diff = self.contentView.frame.width - diff
+                    diff = self.frame.width - diff
                     NSLayoutConstraint.deactivate(tiConstraints)
                     tiConstraints = batch {
                         typeImage.leftAnchor == self.leftAnchor + 4
@@ -807,7 +808,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             if direction == 0 {
                 if xVelocity > 0 {
                     direction = 1
-                    diff = self.contentView.frame.width - diff
+                    diff = self.frame.width - diff
                     action = getFirstAction(left: true)
                     if action == .NONE {
                         sender.cancel()
@@ -833,7 +834,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 }
             }
             
-            let currentTranslation = direction == -1 ? 0 - (self.contentView.bounds.size.width - posx - diff) : posx - diff
+            let currentTranslation = direction == -1 ? 0 - (self.bounds.size.width - posx - diff) : posx - diff
             self.contentView.frame.origin.x = posx - originalLocation
 
             if (direction == -1 && SettingValues.commentActionLeftLeft == .NONE && SettingValues.commentActionLeftRight == .NONE) || (direction == 1 && SettingValues.commentActionRightRight == .NONE && SettingValues.commentActionRightLeft == .NONE) {
@@ -933,7 +934,8 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         } else if sender.state != .began {
             dragCancelled = true
         }
-        
+        print(self.contentView.frame.origin.x)
+
         if dragCancelled || sender.state == .cancelled {
             if self.typeImage.superview == nil {
                 return

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -761,7 +761,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     var tiConstraints = [NSLayoutConstraint]()
     
     @objc func handlePan(_ sender: UIPanGestureRecognizer) {
-        print("First \(self.contentView.frame.origin.x)")
         if sender.state == .began || typeImage == nil {
             dragCancelled = false
             direction = 0
@@ -2612,6 +2611,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     }
     
     override func layoutSubviews() {
+        if typeImage != nil {
+            return
+        }
         super.layoutSubviews()
         var topmargin = 0
         var bottommargin = 2

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1039,6 +1039,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         let ceight = SettingValues.postViewMode == .COMPACT ? CGFloat(4) : CGFloat(8)
         let ctwelve = SettingValues.postViewMode == .COMPACT ? CGFloat(8) : CGFloat(12)
         
+        self.clipsToBounds = true
         if videoView != nil {
             progressDot.widthAnchor == 20
             progressDot.heightAnchor == 20

--- a/Slide for Reddit/PagingCommentViewController.swift
+++ b/Slide for Reddit/PagingCommentViewController.swift
@@ -83,7 +83,7 @@ class PagingCommentViewController: ColorMuxPagingViewController, UIPageViewContr
         self.delegate = self
         self.navigationController?.view.backgroundColor = UIColor.clear
         
-        let firstViewController: UIViewController
+        let firstViewController: CommentViewController
         let sub = self.vCs[0]
         if first && PagingCommentViewController.savedComment != nil && PagingCommentViewController.savedComment!.submission!.getId() == sub.getId() {
             firstViewController = PagingCommentViewController.savedComment!
@@ -94,26 +94,17 @@ class PagingCommentViewController: ColorMuxPagingViewController, UIPageViewContr
         }
         first = false
         
-        for view in view.subviews {
-            if view is UIScrollView {
-                let scrollView = view as! UIScrollView
-                scrollView.delegate = self
-                if scrollView.isPagingEnabled && SettingValues.commentGesturesMode != .NONE {
-                    scrollView.panGestureRecognizer.minimumNumberOfTouches = 2
-                }
-                scrollView.panGestureRecognizer.require(toFail: navigationController!.interactivePopGestureRecognizer!)
-            }
-        }
-        
-        if !(firstViewController as! CommentViewController).loaded {
-            PagingCommentViewController.savedComment = firstViewController as? CommentViewController
-            (firstViewController as! CommentViewController).forceLoad = true
+        if !firstViewController.loaded {
+            PagingCommentViewController.savedComment = firstViewController
+            firstViewController.forceLoad = true
         }
 
         setViewControllers([firstViewController],
                            direction: .forward,
                            animated: false,
-                           completion: nil)
+                           completion: {(_) in
+                            firstViewController.setupSwipeGesture()
+                           })
     }
     
     //From https://stackoverflow.com/a/25167681/3697225
@@ -154,6 +145,9 @@ class PagingCommentViewController: ColorMuxPagingViewController, UIPageViewContr
                 break
             }
         }
+        if currentIndex == 0 {
+            (self.viewControllers?.first as? CommentViewController)?.setupSwipeGesture()
+        }
     }
 
     func pageViewController(_ pageViewController: UIPageViewController,
@@ -181,7 +175,8 @@ class PagingCommentViewController: ColorMuxPagingViewController, UIPageViewContr
             return nil
         }
         
-        return CommentViewController(submission: vCs[previousIndex], single: false)
+        let comment = CommentViewController(submission: vCs[previousIndex], single: false)
+        return comment
     }
     
     func pageViewController(_ pageViewController: UIPageViewController,
@@ -213,8 +208,11 @@ class PagingCommentViewController: ColorMuxPagingViewController, UIPageViewContr
         guard orderedViewControllersCount > nextIndex else {
             return nil
         }
-        
-        return CommentViewController(submission: vCs[nextIndex], single: false)
+        let comment = CommentViewController(submission: vCs[nextIndex], single: false)
+        if nextIndex == 0 {
+            comment.setupSwipeGesture()
+        }
+        return comment
     }
     
 }

--- a/Slide for Reddit/SettingsGestures.swift
+++ b/Slide for Reddit/SettingsGestures.swift
@@ -103,10 +103,10 @@ class SettingsGestures: BubbleSettingTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        if indexPath.row == 0 && indexPath.section == 1 {
+        /*if indexPath.row == 0 && indexPath.section == 1 {
             showCommentGesturesMenu()
             return
-        }
+        }*/
         
         if indexPath.section == 2 {
             showShortcutActionsMenu()
@@ -130,17 +130,17 @@ class SettingsGestures: BubbleSettingTableViewController {
         if indexPath.section != 1 {
             return
         }
-        if indexPath.row == 1 {
+        if indexPath.row == 6 {
             showAction(cell: rightRightActionCell)
-        } else if indexPath.row == 2 {
-            showAction(cell: rightLeftActionCell)
-        } else if indexPath.row == 3 {
-            showAction(cell: leftLeftActionCell)
-        } else if indexPath.row == 4 {
-            showAction(cell: leftRightActionCell)
-        } else if indexPath.row == 5 {
-            showAction(cell: doubleTapActionCell)
         } else if indexPath.row == 6 {
+            showAction(cell: rightLeftActionCell)
+        } else if indexPath.row == 0 {
+            showAction(cell: leftLeftActionCell)
+        } else if indexPath.row == 1 {
+            showAction(cell: leftRightActionCell)
+        } else if indexPath.row == 2 {
+            showAction(cell: doubleTapActionCell)
+        } else if indexPath.row == 3 {
             showAction(cell: forceTouchActionCell)
         }
     }
@@ -380,7 +380,7 @@ class SettingsGestures: BubbleSettingTableViewController {
         self.sideShortcutActionCell.detailTextLabel?.text = SettingValues.sideGesture.description()
         self.sideShortcutActionCell.imageView?.layer.cornerRadius = 5
 
-        if SettingValues.commentGesturesMode == .NONE || SettingValues.commentGesturesMode == .SWIPE_ANYWHERE {
+        /*if SettingValues.commentGesturesMode == .NONE || SettingValues.commentGesturesMode == .SWIPE_ANYWHERE {
             self.rightRightActionCell.isUserInteractionEnabled = false
             self.rightRightActionCell.contentView.alpha = 0.5
             self.rightLeftActionCell.isUserInteractionEnabled = false
@@ -398,7 +398,7 @@ class SettingsGestures: BubbleSettingTableViewController {
             self.leftRightActionCell.contentView.alpha = 1
             self.leftLeftActionCell.isUserInteractionEnabled = true
             self.leftLeftActionCell.contentView.alpha = 1
-        }
+        }*/
         
         if !SettingValues.submissionGesturesEnabled {
             self.leftSubActionCell.isUserInteractionEnabled = false
@@ -440,14 +440,14 @@ class SettingsGestures: BubbleSettingTableViewController {
         switch indexPath.section {
         case 1:
             switch indexPath.row {
-            case 0: return self.commentGesturesCell
+            //case 0: return self.commentGesturesCell
             //case 1: return self.commentCell
-            case 1: return self.rightRightActionCell
-            case 2: return self.rightLeftActionCell
-            case 3: return self.leftLeftActionCell
-            case 4: return self.leftRightActionCell
-            case 5: return self.doubleTapActionCell
-            case 6: return self.forceTouchActionCell
+            //case 1: return self.rightRightActionCell
+            //case 2: return self.rightLeftActionCell
+            case 0: return self.leftLeftActionCell
+            case 1: return self.leftRightActionCell
+            case 2: return self.doubleTapActionCell
+            case 3: return self.forceTouchActionCell
             default: fatalError("Unknown row in section 0")
             }
         case 0:
@@ -470,7 +470,7 @@ class SettingsGestures: BubbleSettingTableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0: return 5 + (canForceTouch ? 1 : 0)
-        case 1: return 6 + (canForceTouch ? 1 : 0)
+        case 1: return 3 + (canForceTouch ? 1 : 0)
         case 2: return 1
         default: fatalError("Unknown number of sections")
         }

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -203,7 +203,9 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
         tableView.verticalAnchors == view.verticalAnchors
         tableView.horizontalAnchors == view.safeHorizontalAnchors
 
-        setupGestures()
+        if SettingValues.submissionGesturesEnabled {
+            setupGestures()
+        }
         /*Disable for now
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(self.panCell))
         panGesture.direction = .horizontal

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -2980,6 +2980,13 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
     }
     
     func setupSwipeGesture() {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            if #available(iOS 14, *) {
+                return
+            } else if SettingValues.appMode == .MULTI_COLUMN {
+                return
+            }
+        }
         fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
         if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController {
             fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
@@ -3053,7 +3060,7 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
             }
             
             let cellPoint = recognizer.location(in: cell.contentView)
-            if cellPoint.x < cell.contentView.frame.width * 0.6 {
+            if cellPoint.x < cell.contentView.frame.width * 0.75 {
                 recognizer.cancel()
                 return
             }

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -379,6 +379,16 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             toolbar!.horizontalAnchors == menuNav!.view.horizontalAnchors
             toolbar!.topAnchor == menuNav!.view.topAnchor
             toolbar!.heightAnchor == 90
+            
+            /*(var fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
+            if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController {
+                fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
+                toolbar!.addGestureRecognizer(fullWidthBackGestureRecognizer)
+                if #available(iOS 13.4, *) {
+                    fullWidthBackGestureRecognizer.allowedScrollTypesMask = .continuous
+                }
+            }*/
+
 
             self.menuNav?.setSubreddit(subreddit: sub)
             

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -2970,6 +2970,10 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
         let fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
         if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController {
             fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
+            fullWidthBackGestureRecognizer.require(toFail: tableView.panGestureRecognizer)
+            if let navGesture = self.navigationController?.interactivePopGestureRecognizer {
+                fullWidthBackGestureRecognizer.require(toFail: navGesture)
+            }
             fullWidthBackGestureRecognizer.delegate = self
             //parent.requireFailureOf(fullWidthBackGestureRecognizer)
             tableView.addGestureRecognizer(fullWidthBackGestureRecognizer)
@@ -2986,8 +2990,7 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = panGestureRecognizer.translation(in: tableView)
-            let velocity = panGestureRecognizer.velocity(in: tableView)
-            if translation.x >= 0 && abs(translation.y) < 1 && velocity.x > 120 {
+            if translation.x >= 0 {
                 return true
             }
             return false

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -274,7 +274,8 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        navigationController?.setToolbarHidden(true, animated: false)
+
         isModal = navigationController?.presentingViewController != nil || self.modalPresentationStyle == .fullScreen
 
         if isModal {
@@ -439,6 +440,7 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
         if toolbarEnabled && !MainViewController.isOffline {
             showMenuNav()
             self.isToolbarHidden = false
@@ -451,10 +453,6 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
                 }
             } else {
                 show(true)
-            }
-        } else {
-            if single {
-                navigationController?.setToolbarHidden(true, animated: false)
             }
         }
         if !links.isEmpty {
@@ -2988,7 +2986,8 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = panGestureRecognizer.translation(in: tableView)
-            if translation.x >= 0 {
+            let velocity = panGestureRecognizer.velocity(in: tableView)
+            if translation.x >= 0 && abs(translation.y) < 1 && velocity.x > 120 {
                 return true
             }
             return false

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -290,6 +290,8 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
         }
 
         self.isGallery = UserDefaults.standard.bool(forKey: "isgallery+" + sub)
+        
+        menuNav?.configureToolbarSwipe()
 
         server?.stop()
         loop?.stop()

--- a/Slide for Reddit/SplitMainViewController.swift
+++ b/Slide for Reddit/SplitMainViewController.swift
@@ -20,6 +20,9 @@ import UIKit
 import WatchConnectivity
 
 class SplitMainViewController: MainViewController {
+    
+    static var isFirst = true
+
     override var shouldAutomaticallyForwardAppearanceMethods: Bool {
         return true
     }
@@ -161,6 +164,8 @@ class SplitMainViewController: MainViewController {
     }
 
     override func viewDidLoad() {
+        SplitMainViewController.isFirst = true
+        
         self.navToMux = self.navigationController?.navigationBar
         self.color1 = ColorUtil.theme.foregroundColor
         self.color2 = ColorUtil.theme.foregroundColor
@@ -239,6 +244,9 @@ class SplitMainViewController: MainViewController {
         guard page < finalSubs.count else { return }
         currentIndex = page
         let vc = self.viewControllers![0] as! SingleSubredditViewController
+        if currentIndex == 0 && SettingValues.subredditBar {
+            vc.setupSwipeGesture()
+        }
         MainViewController.current = vc.sub
         UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: "Viewing \(vc.sub)")
         self.currentTitle = MainViewController.current
@@ -505,7 +513,6 @@ class SplitMainViewController: MainViewController {
         }
         
         let firstViewController = SingleSubredditViewController(subName: finalSubs[newIndex], parent: self)
-        
         weak var weakPageVc = self
         setViewControllers([firstViewController],
                            direction: .forward,

--- a/Slide for Reddit/SplitMainViewController.swift
+++ b/Slide for Reddit/SplitMainViewController.swift
@@ -491,19 +491,7 @@ class SplitMainViewController: MainViewController {
         subs.append(UIMutableApplicationShortcutItem.init(type: "me.ccrama.redditslide.subreddit", localizedTitle: "Open link", localizedSubtitle: "Open current clipboard url", icon: UIApplicationShortcutIcon.init(templateImageName: "nav"), userInfo: [ "clipboard": "true" as NSSecureCoding ]))
         subs.reverse()
         UIApplication.shared.shortcutItems = subs
-        
-        if SettingValues.submissionGesturesEnabled {
-            for view in view.subviews {
-                if view is UIScrollView {
-                    let scrollView = view as! UIScrollView
-                    if scrollView.isPagingEnabled {
-                        scrollView.panGestureRecognizer.minimumNumberOfTouches = 2
-                    }
-                    break
-                }
-            }
-        }
-        
+                
         var newIndex = 0
         
         for sub in self.finalSubs {

--- a/Slide for Reddit/SubredditToolbarSearchViewController.swift
+++ b/Slide for Reddit/SubredditToolbarSearchViewController.swift
@@ -258,15 +258,22 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
     }
     
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if let recognizer = gestureRecognizer as? UIPanGestureRecognizer,
-            recognizer.velocity(in: self.view).y < 0,
-            let topView = topView,
-            topView.alpha == 0 {
-            return false
+        if let recognizer = gestureRecognizer as? UIPanGestureRecognizer {
+            if recognizer == self.gestureRecognizer {
+                print(recognizer.velocity(in: self.view))
+                let velocity = recognizer.velocity(in: self.view)
+                if let topView = topView, velocity.y < 0, topView.alpha == 0 {
+                    return false
+                } else if abs(velocity.x) > abs(velocity.y) {
+                    return false
+                }
+            } else {
+                return recognizer.velocity(in: self.view).x < 0
+            }
         }
         return true
     }
-    
+        
     func update(_ recognizer: UIPanGestureRecognizer) {
         let translation = recognizer.translation(in: self.view)
         let y = self.view.frame.minY
@@ -649,6 +656,17 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
     func configureGestures() {
         gestureRecognizer = UIPanGestureRecognizer()
         view.addGestureRecognizer(gestureRecognizer)
+        
+        var fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
+        if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController {
+            fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
+            fullWidthBackGestureRecognizer.require(toFail: gestureRecognizer)
+            fullWidthBackGestureRecognizer.delegate = self
+            self.view.addGestureRecognizer(fullWidthBackGestureRecognizer)
+            if #available(iOS 13.4, *) {
+                fullWidthBackGestureRecognizer.allowedScrollTypesMask = .continuous
+            }
+        }
         
         gestureRecognizer.delegate = self
         gestureRecognizer.addTarget(self, action: #selector(viewPanned(sender:)))

--- a/Slide for Reddit/SubredditToolbarSearchViewController.swift
+++ b/Slide for Reddit/SubredditToolbarSearchViewController.swift
@@ -25,6 +25,7 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
     var lastY: CGFloat = 0.0
     var timer: Timer?
     var isSearchComplete = false
+    var toolbarDone = false
     
     var subredditInfoView = UIView()
     var subTitleView = UILabel()
@@ -159,7 +160,6 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
 
         configureViews()
         configureLayout()
-        configureGestures()
         
         configureBackground()
 
@@ -260,7 +260,6 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if let recognizer = gestureRecognizer as? UIPanGestureRecognizer {
             if recognizer == self.gestureRecognizer {
-                print(recognizer.velocity(in: self.view))
                 let velocity = recognizer.velocity(in: self.view)
                 if let topView = topView, velocity.y < 0, topView.alpha == 0 {
                     return false
@@ -653,20 +652,24 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
         }
     }
 
+    func configureToolbarSwipe() {
+        if !toolbarDone && gestureRecognizer != nil {
+            toolbarDone = true
+            let fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
+            if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer ?? parent?.parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets") {
+                fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
+                fullWidthBackGestureRecognizer.require(toFail: gestureRecognizer)
+                fullWidthBackGestureRecognizer.delegate = self
+                self.view.addGestureRecognizer(fullWidthBackGestureRecognizer)
+                if #available(iOS 13.4, *) {
+                    fullWidthBackGestureRecognizer.allowedScrollTypesMask = .continuous
+                }
+            }
+        }
+    }
     func configureGestures() {
         gestureRecognizer = UIPanGestureRecognizer()
         view.addGestureRecognizer(gestureRecognizer)
-        
-        var fullWidthBackGestureRecognizer = UIPanGestureRecognizer()
-        if let interactivePopGestureRecognizer = parent?.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets"), parent is ColorMuxPagingViewController {
-            fullWidthBackGestureRecognizer.setValue(targets, forKey: "targets")
-            fullWidthBackGestureRecognizer.require(toFail: gestureRecognizer)
-            fullWidthBackGestureRecognizer.delegate = self
-            self.view.addGestureRecognizer(fullWidthBackGestureRecognizer)
-            if #available(iOS 13.4, *) {
-                fullWidthBackGestureRecognizer.allowedScrollTypesMask = .continuous
-            }
-        }
         
         gestureRecognizer.delegate = self
         gestureRecognizer.addTarget(self, action: #selector(viewPanned(sender:)))

--- a/Slide for Reddit/VCPresenter.swift
+++ b/Slide for Reddit/VCPresenter.swift
@@ -42,6 +42,9 @@ public class VCPresenter {
         if (UIDevice.current.userInterfaceIdiom != .pad && viewController is PagingCommentViewController && !parentIs13) || (viewController is WebsiteViewController && parentNavigationController != nil) || viewController is SFHideSafariViewController || SettingValues.disable13Popup {
             override13 = false
         }
+        
+        override13 = override13 && UIDevice.current.userInterfaceIdiom == .pad
+        
         if (viewController is PagingCommentViewController || viewController is CommentViewController) && (parentViewController?.splitViewController != nil && UIDevice.current.userInterfaceIdiom == .pad && SettingValues.appMode != .MULTI_COLUMN) && !(parentViewController is CommentViewController) && (!override13 || !parentIs13) {
             (parentViewController!.splitViewController)?.showDetailViewController(SwipeForwardNavigationController(rootViewController: viewController), sender: nil)
             return

--- a/Slide for Reddit/VCPresenter.swift
+++ b/Slide for Reddit/VCPresenter.swift
@@ -43,6 +43,8 @@ public class VCPresenter {
             override13 = false
         }
         
+        var respectedOverride13 = override13
+
         override13 = override13 && (UIDevice.current.userInterfaceIdiom == .pad || (viewController is UIPageViewController || viewController is SettingsViewController))
         
         if (viewController is PagingCommentViewController || viewController is CommentViewController) && (parentViewController?.splitViewController != nil && UIDevice.current.userInterfaceIdiom == .pad && SettingValues.appMode != .MULTI_COLUMN) && !(parentViewController is CommentViewController) && (!override13 || !parentIs13) {
@@ -71,9 +73,9 @@ public class VCPresenter {
             //Let's figure out how to present it
             let small: Bool = popupIfPossible && UIScreen.main.traitCollection.userInterfaceIdiom == .pad && UIApplication.shared.statusBarOrientation != .portrait
 
-            if small || override13 {
+            if small || override13 || respectedOverride13 {
                 newParent.modalPresentationStyle = .pageSheet
-                if !override13 {
+                if !override13 && !respectedOverride13 {
                     newParent.modalTransitionStyle = .crossDissolve
                 }
             } else {

--- a/Slide for Reddit/VCPresenter.swift
+++ b/Slide for Reddit/VCPresenter.swift
@@ -43,7 +43,7 @@ public class VCPresenter {
             override13 = false
         }
         
-        override13 = override13 && UIDevice.current.userInterfaceIdiom == .pad
+        override13 = override13 && (UIDevice.current.userInterfaceIdiom == .pad || (viewController is UIPageViewController || viewController is SettingsViewController))
         
         if (viewController is PagingCommentViewController || viewController is CommentViewController) && (parentViewController?.splitViewController != nil && UIDevice.current.userInterfaceIdiom == .pad && SettingValues.appMode != .MULTI_COLUMN) && !(parentViewController is CommentViewController) && (!override13 || !parentIs13) {
             (parentViewController!.splitViewController)?.showDetailViewController(SwipeForwardNavigationController(rootViewController: viewController), sender: nil)

--- a/Slide for RedditTests/Info.plist
+++ b/Slide for RedditTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 </dict>
 </plist>

--- a/Slide for RedditUITests/Info.plist
+++ b/Slide for RedditUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 </dict>
 </plist>

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,32 +5,32 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000445">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000363">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: xcode_select" time="0.000323">
+      <testcase classname="fastlane.lanes" name="1: xcode_select" time="0.000296">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: increment_build_number" time="2.256707">
+      <testcase classname="fastlane.lanes" name="2: increment_build_number" time="2.075598">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: match" time="5.615185">
+      <testcase classname="fastlane.lanes" name="3: match" time="5.645089">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: build_app" time="398.96284">
+      <testcase classname="fastlane.lanes" name="4: build_app" time="408.992271">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="5: upload_to_testflight" time="9.72963">
+      <testcase classname="fastlane.lanes" name="5: upload_to_testflight" time="5.980332">
         
           <failure message="/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/actions/actions_helper.rb:48:in `execute_action'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:253:in `block in execute_action'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:227:in `chdir'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:227:in `execute_action'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'&#10;Fastfile:53:in `block (2 levels) in parsing_binding'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/lane.rb:33:in `call'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:49:in `block in execute'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:45:in `chdir'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/runner.rb:45:in `execute'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/lane_manager.rb:47:in `cruise_lane'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/commands_generator.rb:108:in `block (2 levels) in run'&#10;/Library/Ruby/Gems/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'&#10;/Library/Ruby/Gems/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'&#10;/Library/Ruby/Gems/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:76:in `run!'&#10;/Library/Ruby/Gems/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/commands_generator.rb:352:in `run'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/commands_generator.rb:41:in `start'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/fastlane/lib/fastlane/cli_tools_distributor.rb:119:in `take_off'&#10;/Library/Ruby/Gems/2.6.0/gems/fastlane-2.149.1/bin/fastlane:23:in `&lt;top (required)&gt;'&#10;/usr/local/bin/fastlane:23:in `load'&#10;/usr/local/bin/fastlane:23:in `&lt;main&gt;'&#10;&#10;Error uploading ipa file, for more information see above" />
         


### PR DESCRIPTION
This PR handles a lot.

- Comments and submissions can now swipe at any time
- Gestures are now enabled on the left 25% of cell views, and can run even with swiping between subs/comments enabled
- Adds swipe back from anywhere to the first presented Subreddit or Comment if in a swiping view
- Removes two right-side gestures for comments (might do this later)
- Adds swipe back from anywhere to SingleSubredditVC toolbar