### PR TITLE
Move dependencies to Swift Package Manager, fix SwiftUI previews

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,6 @@ target 'Slide for Reddit' do
   pod 'YYText'
   pod 'Alamofire', '~> 4.3'
   pod 'SwiftyJSON', :git => 'https://github.com/ccrama/SwiftyJSON.git', :branch => 'hotfix-xcode12'
-  pod 'RealmSwift'
   pod 'Anchorage', '~>4.3'
   pod 'Then'
   pod "YoutubePlayer-in-WKWebView", "~> 0.3.0"

--- a/Podfile
+++ b/Podfile
@@ -7,11 +7,8 @@ target 'Slide for Reddit' do
   # Pods for Slide for Reddit
 
   pod 'reddift', :git =>  'https://github.com/ccrama/reddift'
-  pod 'SDWebImage'
   pod 'MKColorPicker', :git => 'https://github.com/ccrama/MKColorPicker'
-  pod 'BadgeSwift', '~> 8.0'
   pod 'LicensesViewController', '~> 0.7.0'
-  pod 'BiometricAuthentication'
   pod 'OpalImagePicker'
   pod 'MaterialComponents/ActivityIndicator'
   pod 'MaterialComponents/Tabs'

--- a/Podfile
+++ b/Podfile
@@ -16,17 +16,13 @@ target 'Slide for Reddit' do
   pod 'SwiftEntryKit', :git => 'https://github.com/ccrama/SwiftEntryKit'
   pod 'SubtleVolume'
   pod 'SDCAlertView', :git => 'https://github.com/ccrama/SDCAlertView'
-  pod 'Embassy', '~> 4.1.0'
   pod 'MTColorDistance'
   pod 'SwiftLinkPreview', '~> 3.0.1'
   pod 'DTCoreText', :git => 'https://github.com/Cocoanetics/DTCoreText'
-  pod 'Starscream', '~> 3.1.1'
   pod 'RLBAlertsPickers', :git => 'https://github.com/ccrama/Alerts-Pickers'
   pod 'YYText'
   pod 'Alamofire', '~> 4.3'
   pod 'SwiftyJSON', :git => 'https://github.com/ccrama/SwiftyJSON.git', :branch => 'hotfix-xcode12'
-  pod 'Anchorage', '~>4.3'
-  pod 'Then'
   pod "YoutubePlayer-in-WKWebView", "~> 0.3.0"
   pod 'TGPControls'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - Alamofire (4.9.1)
-  - Anchorage (4.4.0)
   - DTCoreText (1.6.25):
     - DTCoreText/Core (= 1.6.25)
     - DTFoundation/Core (~> 1.7.5)
@@ -18,7 +17,6 @@ PODS:
     - DTFoundation/Core
   - DTFoundation/UIKit (1.7.15):
     - DTFoundation/Core
-  - Embassy (4.1.1)
   - HTMLSpecialCharacters (1.3.6)
   - LicensesViewController (0.7.0)
   - MaterialComponents/ActivityIndicator (116.0.0):
@@ -83,7 +81,6 @@ PODS:
     - MiniKeychain
   - RLBAlertsPickers (1.1.1)
   - SDCAlertView (10.0)
-  - Starscream (3.1.1)
   - SubtleVolume (1.1.0)
   - SwiftEntryKit (1.2.1):
     - QuickLayout (= 3.0.0)
@@ -91,15 +88,12 @@ PODS:
   - SwiftLint (0.40.2)
   - SwiftyJSON (5.0.0)
   - TGPControls (5.1.0)
-  - Then (2.7.0)
   - YoutubePlayer-in-WKWebView (0.3.4)
   - YYText (1.0.7)
 
 DEPENDENCIES:
   - Alamofire (~> 4.3)
-  - Anchorage (~> 4.3)
   - DTCoreText (from `https://github.com/Cocoanetics/DTCoreText`)
-  - Embassy (~> 4.1.0)
   - LicensesViewController (~> 0.7.0)
   - MaterialComponents/ActivityIndicator
   - MaterialComponents/ProgressView
@@ -110,23 +104,19 @@ DEPENDENCIES:
   - reddift (from `https://github.com/ccrama/reddift`)
   - RLBAlertsPickers (from `https://github.com/ccrama/Alerts-Pickers`)
   - SDCAlertView (from `https://github.com/ccrama/SDCAlertView`)
-  - Starscream (~> 3.1.1)
   - SubtleVolume
   - SwiftEntryKit (from `https://github.com/ccrama/SwiftEntryKit`)
   - SwiftLinkPreview (~> 3.0.1)
   - SwiftLint
   - SwiftyJSON (from `https://github.com/ccrama/SwiftyJSON.git`, branch `hotfix-xcode12`)
   - TGPControls
-  - Then
   - YoutubePlayer-in-WKWebView (~> 0.3.0)
   - YYText
 
 SPEC REPOS:
   trunk:
     - Alamofire
-    - Anchorage
     - DTFoundation
-    - Embassy
     - HTMLSpecialCharacters
     - LicensesViewController
     - MaterialComponents
@@ -138,12 +128,10 @@ SPEC REPOS:
     - MTColorDistance
     - OpalImagePicker
     - QuickLayout
-    - Starscream
     - SubtleVolume
     - SwiftLinkPreview
     - SwiftLint
     - TGPControls
-    - Then
     - YoutubePlayer-in-WKWebView
     - YYText
 
@@ -189,10 +177,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
-  Anchorage: d7f02c4f9425b537053237aab11ae97e59b55f36
   DTCoreText: e92f4cf6b36d9d71ce4436d12cf089d74ab0596b
   DTFoundation: 767ca882209ef4d5132ec7e702526d5ed5bb71a2
-  Embassy: eb36dc783ea20b792426461bbaff8c3f256e0331
   HTMLSpecialCharacters: edc707cc4bcdc92eb3b9551de8cff94c1e6f9a19
   LicensesViewController: 2f7bba13b3cec7516d4990e41df297720fdbaaab
   MaterialComponents: a6cf920307c2864f71e37972620f24c4d14fae8d
@@ -208,17 +194,15 @@ SPEC CHECKSUMS:
   reddift: 42af05f3d2db6315cdf144be9256de36e86a523a
   RLBAlertsPickers: c93e83c13526a5840b67eb52f702d3f83eeaac6a
   SDCAlertView: 5fbc48cae6d7bf9781097e3f27883924ef3b922c
-  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SubtleVolume: 101038d203018736bcd1df3ac95bcc0f6b8640ce
   SwiftEntryKit: 1661b766dd22b07679e6ebb326ccfbd81ceb0a20
   SwiftLinkPreview: 7524438c43bf63a5041615713777c3d8f19a9a31
   SwiftLint: 1216c910d27c2633ade33b4f071bb6b930982e62
   SwiftyJSON: f0574c07d8ca1644050db687067209e3033a89a0
   TGPControls: 52c0770bee9c9aee364f1559cc627fc01ea5e8b2
-  Then: acfe0be7e98221c6204e12f8161459606d5d822d
   YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717
   YYText: 5c461d709e24d55a182d1441c41dc639a18a4849
 
-PODFILE CHECKSUM: 1afb36b24097d50c9fd4d892ed1d3c62a32539c5
+PODFILE CHECKSUM: 3ba39067eb1b6cbb76b4f6c8739f48bf578e2f7b
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,6 @@
 PODS:
   - Alamofire (4.9.1)
   - Anchorage (4.4.0)
-  - BadgeSwift (8.0.0)
-  - BiometricAuthentication (3.1.2)
   - DTCoreText (1.6.25):
     - DTCoreText/Core (= 1.6.25)
     - DTFoundation/Core (~> 1.7.5)
@@ -85,9 +83,6 @@ PODS:
     - MiniKeychain
   - RLBAlertsPickers (1.1.1)
   - SDCAlertView (10.0)
-  - SDWebImage (5.9.1):
-    - SDWebImage/Core (= 5.9.1)
-  - SDWebImage/Core (5.9.1)
   - Starscream (3.1.1)
   - SubtleVolume (1.1.0)
   - SwiftEntryKit (1.2.1):
@@ -103,8 +98,6 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.3)
   - Anchorage (~> 4.3)
-  - BadgeSwift (~> 8.0)
-  - BiometricAuthentication
   - DTCoreText (from `https://github.com/Cocoanetics/DTCoreText`)
   - Embassy (~> 4.1.0)
   - LicensesViewController (~> 0.7.0)
@@ -117,7 +110,6 @@ DEPENDENCIES:
   - reddift (from `https://github.com/ccrama/reddift`)
   - RLBAlertsPickers (from `https://github.com/ccrama/Alerts-Pickers`)
   - SDCAlertView (from `https://github.com/ccrama/SDCAlertView`)
-  - SDWebImage
   - Starscream (~> 3.1.1)
   - SubtleVolume
   - SwiftEntryKit (from `https://github.com/ccrama/SwiftEntryKit`)
@@ -133,8 +125,6 @@ SPEC REPOS:
   trunk:
     - Alamofire
     - Anchorage
-    - BadgeSwift
-    - BiometricAuthentication
     - DTFoundation
     - Embassy
     - HTMLSpecialCharacters
@@ -148,7 +138,6 @@ SPEC REPOS:
     - MTColorDistance
     - OpalImagePicker
     - QuickLayout
-    - SDWebImage
     - Starscream
     - SubtleVolume
     - SwiftLinkPreview
@@ -201,8 +190,6 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   Anchorage: d7f02c4f9425b537053237aab11ae97e59b55f36
-  BadgeSwift: a81547ffde1f462bb5fc02e3fa3fdcbc1b888354
-  BiometricAuthentication: 36445f3ab77699489f91995bed887be89890afac
   DTCoreText: e92f4cf6b36d9d71ce4436d12cf089d74ab0596b
   DTFoundation: 767ca882209ef4d5132ec7e702526d5ed5bb71a2
   Embassy: eb36dc783ea20b792426461bbaff8c3f256e0331
@@ -221,7 +208,6 @@ SPEC CHECKSUMS:
   reddift: 42af05f3d2db6315cdf144be9256de36e86a523a
   RLBAlertsPickers: c93e83c13526a5840b67eb52f702d3f83eeaac6a
   SDCAlertView: 5fbc48cae6d7bf9781097e3f27883924ef3b922c
-  SDWebImage: a990c053fff71e388a10f3357edb0be17929c9c5
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SubtleVolume: 101038d203018736bcd1df3ac95bcc0f6b8640ce
   SwiftEntryKit: 1661b766dd22b07679e6ebb326ccfbd81ceb0a20
@@ -233,6 +219,6 @@ SPEC CHECKSUMS:
   YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717
   YYText: 5c461d709e24d55a182d1441c41dc639a18a4849
 
-PODFILE CHECKSUM: f5c9d54873947e059a5417aec07c8f8b99bf13eb
+PODFILE CHECKSUM: 1afb36b24097d50c9fd4d892ed1d3c62a32539c5
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -80,11 +80,6 @@ PODS:
   - MTColorDistance (0.0.3)
   - OpalImagePicker (3.0.0)
   - QuickLayout (3.0.0)
-  - Realm (5.4.0):
-    - Realm/Headers (= 5.4.0)
-  - Realm/Headers (5.4.0)
-  - RealmSwift (5.4.0):
-    - Realm (= 5.4.0)
   - reddift (2.0.3):
     - HTMLSpecialCharacters
     - MiniKeychain
@@ -119,7 +114,6 @@ DEPENDENCIES:
   - MKColorPicker (from `https://github.com/ccrama/MKColorPicker`)
   - MTColorDistance
   - OpalImagePicker
-  - RealmSwift
   - reddift (from `https://github.com/ccrama/reddift`)
   - RLBAlertsPickers (from `https://github.com/ccrama/Alerts-Pickers`)
   - SDCAlertView (from `https://github.com/ccrama/SDCAlertView`)
@@ -154,8 +148,6 @@ SPEC REPOS:
     - MTColorDistance
     - OpalImagePicker
     - QuickLayout
-    - Realm
-    - RealmSwift
     - SDWebImage
     - Starscream
     - SubtleVolume
@@ -226,8 +218,6 @@ SPEC CHECKSUMS:
   MTColorDistance: 5ab8708eb88bc22d4d88e309d09eb912f3a6e27b
   OpalImagePicker: 38e772dd93a54431fc516b33e1f337c50f745834
   QuickLayout: 07b45a72b10083fee3f095990cfed1c1e7b27f0a
-  Realm: 8949757d76e2451a53d727954c607e49c2542b77
-  RealmSwift: 0b7d7121e842724188123c6086831ae6d2952050
   reddift: 42af05f3d2db6315cdf144be9256de36e86a523a
   RLBAlertsPickers: c93e83c13526a5840b67eb52f702d3f83eeaac6a
   SDCAlertView: 5fbc48cae6d7bf9781097e3f27883924ef3b922c
@@ -243,6 +233,6 @@ SPEC CHECKSUMS:
   YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717
   YYText: 5c461d709e24d55a182d1441c41dc639a18a4849
 
-PODFILE CHECKSUM: 33060347e8b00e95fe117e381626fbfbb6465ae7
+PODFILE CHECKSUM: f5c9d54873947e059a5417aec07c8f8b99bf13eb
 
 COCOAPODS: 1.8.4

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -49,6 +49,8 @@
 		B49EFE382511A18F002D6AEE /* HotPostsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EFE372511A18F002D6AEE /* HotPostsWidget.swift */; };
 		B49EFE482511A1D1002D6AEE /* FavoriteSubredditsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EFE472511A1D1002D6AEE /* FavoriteSubredditsWidget.swift */; };
 		B49EFE522511A221002D6AEE /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EFE512511A221002D6AEE /* UIImage+Extensions.swift */; };
+		B4F333B925126FCE0032BB64 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333B825126FCE0032BB64 /* Realm */; };
+		B4F333BB25126FCE0032BB64 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333BA25126FCE0032BB64 /* RealmSwift */; };
 		B776B17D5CA92860424F37C0 /* ModQueueContributionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BA7C2B7217C3875F3BEC /* ModQueueContributionLoader.swift */; };
 		B776B1DF80711B443ED76B61 /* SettingsPro.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776B2AEE4A2438F5803329C /* SettingsPro.swift */; };
 		B776B1E23F4DEC18069F1579 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BC65995FE8D1EE75E2AB /* MediaViewController.swift */; };
@@ -808,7 +810,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4F333B925126FCE0032BB64 /* Realm in Frameworks */,
 				BEC2AB3A250D8D2C00AD5BEA /* WidgetKit.framework in Frameworks */,
+				B4F333BB25126FCE0032BB64 /* RealmSwift in Frameworks */,
 				BE51BE6520C7386A00DFFD8B /* StoreKit.framework in Frameworks */,
 				BE2E9F0823492B4300FE07B4 /* CloudKit.framework in Frameworks */,
 				BE7BFB481F1997BA009CA2E1 /* MapKit.framework in Frameworks */,
@@ -1523,6 +1527,10 @@
 				BED90FEB250BF71800090DF5 /* PBXTargetDependency */,
 			);
 			name = "Slide for Reddit";
+			packageProductDependencies = (
+				B4F333B825126FCE0032BB64 /* Realm */,
+				B4F333BA25126FCE0032BB64 /* RealmSwift */,
+			);
 			productName = "Slide for Reddit";
 			productReference = BE8FCA041E0C46090063B8EF /* Slide for Reddit.app */;
 			productType = "com.apple.product-type.application";
@@ -1683,6 +1691,9 @@
 				Base,
 			);
 			mainGroup = BE8FC9FB1E0C46090063B8EF;
+			packageReferences = (
+				B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+			);
 			productRefGroup = BE8FCA051E0C46090063B8EF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1947,8 +1958,6 @@
 				"${BUILT_PRODUCTS_DIR}/OpalImagePicker/OpalImagePicker.framework",
 				"${BUILT_PRODUCTS_DIR}/QuickLayout/QuickLayout.framework",
 				"${BUILT_PRODUCTS_DIR}/RLBAlertsPickers/RLBAlertsPickers.framework",
-				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
-				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SDCAlertView/SDCAlertView.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
@@ -1984,8 +1993,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpalImagePicker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/QuickLayout.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RLBAlertsPickers.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDCAlertView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
@@ -2462,7 +2469,11 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide for Apple Watch Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2491,7 +2502,11 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide for Apple Watch Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = ccrama.me.redditslide.bundledwatchkitapp.watchkitextension;
@@ -2521,8 +2536,12 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Open in Slide/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2549,8 +2568,12 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Open in Slide/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "ccrama.me.redditslide.bundledOpen-in-Slide";
@@ -2674,7 +2697,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USR_BASE_IDENTIFIER = "$(USR_DOMAIN).redditslide";
 				USR_DISPLAY_NAME = Slide;
@@ -2699,8 +2723,11 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = "Slide for Reddit/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2738,8 +2765,11 @@
 				GCC_OPTIMIZATION_LEVEL = fast;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = "Slide for Reddit/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2767,7 +2797,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				INFOPLIST_FILE = "Slide for RedditTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2784,7 +2818,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 68GVUVA6AU;
 				INFOPLIST_FILE = "Slide for RedditTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2800,7 +2838,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				INFOPLIST_FILE = "Slide for RedditUITests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2816,7 +2858,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = 68GVUVA6AU;
 				INFOPLIST_FILE = "Slide for RedditUITests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(USR_DOMAIN).Slide-for-RedditUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2837,7 +2883,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide Screenshot Automation/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "ccrama.me.Slide-Screenshot-Automation";
@@ -2861,7 +2911,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide Screenshot Automation/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "ccrama.me.Slide-Screenshot-Automation";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2891,7 +2945,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide Widgets/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2922,7 +2980,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Slide Widgets/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MARKETING_VERSION = 5.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = ccrama.me.redditslide.bundledwidgets;
@@ -3019,6 +3081,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B4F333B825126FCE0032BB64 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = Realm;
+		};
+		B4F333BA25126FCE0032BB64 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = RealmSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BE8FC9FC1E0C46090063B8EF /* Project object */;
 }

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		B49EFE522511A221002D6AEE /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49EFE512511A221002D6AEE /* UIImage+Extensions.swift */; };
 		B4F333B925126FCE0032BB64 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333B825126FCE0032BB64 /* Realm */; };
 		B4F333BB25126FCE0032BB64 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333BA25126FCE0032BB64 /* RealmSwift */; };
+		B4F333E1251273AF0032BB64 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333E0251273AF0032BB64 /* SDWebImage */; };
+		B4F333EB251274050032BB64 /* BadgeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333EA251274050032BB64 /* BadgeSwift */; };
+		B4F333F52512742E0032BB64 /* BiometricAuthentication in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333F42512742E0032BB64 /* BiometricAuthentication */; };
 		B776B17D5CA92860424F37C0 /* ModQueueContributionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BA7C2B7217C3875F3BEC /* ModQueueContributionLoader.swift */; };
 		B776B1DF80711B443ED76B61 /* SettingsPro.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776B2AEE4A2438F5803329C /* SettingsPro.swift */; };
 		B776B1E23F4DEC18069F1579 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BC65995FE8D1EE75E2AB /* MediaViewController.swift */; };
@@ -811,8 +814,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4F333B925126FCE0032BB64 /* Realm in Frameworks */,
+				B4F333F52512742E0032BB64 /* BiometricAuthentication in Frameworks */,
 				BEC2AB3A250D8D2C00AD5BEA /* WidgetKit.framework in Frameworks */,
+				B4F333E1251273AF0032BB64 /* SDWebImage in Frameworks */,
 				B4F333BB25126FCE0032BB64 /* RealmSwift in Frameworks */,
+				B4F333EB251274050032BB64 /* BadgeSwift in Frameworks */,
 				BE51BE6520C7386A00DFFD8B /* StoreKit.framework in Frameworks */,
 				BE2E9F0823492B4300FE07B4 /* CloudKit.framework in Frameworks */,
 				BE7BFB481F1997BA009CA2E1 /* MapKit.framework in Frameworks */,
@@ -1530,6 +1536,9 @@
 			packageProductDependencies = (
 				B4F333B825126FCE0032BB64 /* Realm */,
 				B4F333BA25126FCE0032BB64 /* RealmSwift */,
+				B4F333E0251273AF0032BB64 /* SDWebImage */,
+				B4F333EA251274050032BB64 /* BadgeSwift */,
+				B4F333F42512742E0032BB64 /* BiometricAuthentication */,
 			);
 			productName = "Slide for Reddit";
 			productReference = BE8FCA041E0C46090063B8EF /* Slide for Reddit.app */;
@@ -1693,6 +1702,9 @@
 			mainGroup = BE8FC9FB1E0C46090063B8EF;
 			packageReferences = (
 				B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+				B4F333DF251273AF0032BB64 /* XCRemoteSwiftPackageReference "SDWebImage" */,
+				B4F333E9251274050032BB64 /* XCRemoteSwiftPackageReference "swift-badge" */,
+				B4F333F32512742E0032BB64 /* XCRemoteSwiftPackageReference "BiometricAuthentication" */,
 			);
 			productRefGroup = BE8FCA051E0C46090063B8EF /* Products */;
 			projectDirPath = "";
@@ -1936,75 +1948,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Slide for Reddit/Pods-Slide for Reddit-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/Anchorage/Anchorage.framework",
-				"${BUILT_PRODUCTS_DIR}/BadgeSwift/BadgeSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/BiometricAuthentication/BiometricAuthentication.framework",
-				"${BUILT_PRODUCTS_DIR}/DTCoreText/DTCoreText.framework",
-				"${BUILT_PRODUCTS_DIR}/DTFoundation/DTFoundation.framework",
-				"${BUILT_PRODUCTS_DIR}/Embassy/Embassy.framework",
-				"${BUILT_PRODUCTS_DIR}/HTMLSpecialCharacters/HTMLSpecialCharacters.framework",
-				"${BUILT_PRODUCTS_DIR}/LicensesViewController/LicensesViewController.framework",
-				"${BUILT_PRODUCTS_DIR}/MDFInternationalization/MDFInternationalization.framework",
-				"${BUILT_PRODUCTS_DIR}/MDFTextAccessibility/MDFTextAccessibility.framework",
-				"${BUILT_PRODUCTS_DIR}/MKColorPicker/MKColorPicker.framework",
-				"${BUILT_PRODUCTS_DIR}/MTColorDistance/MTColorDistance.framework",
-				"${BUILT_PRODUCTS_DIR}/MaterialComponents/MaterialComponents.framework",
-				"${BUILT_PRODUCTS_DIR}/MiniKeychain/MiniKeychain.framework",
-				"${BUILT_PRODUCTS_DIR}/MotionAnimator/MotionAnimator.framework",
-				"${BUILT_PRODUCTS_DIR}/MotionInterchange/MotionInterchange.framework",
-				"${BUILT_PRODUCTS_DIR}/OpalImagePicker/OpalImagePicker.framework",
-				"${BUILT_PRODUCTS_DIR}/QuickLayout/QuickLayout.framework",
-				"${BUILT_PRODUCTS_DIR}/RLBAlertsPickers/RLBAlertsPickers.framework",
-				"${BUILT_PRODUCTS_DIR}/SDCAlertView/SDCAlertView.framework",
-				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
-				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${BUILT_PRODUCTS_DIR}/SubtleVolume/SubtleVolume.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftEntryKit/SwiftEntryKit.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftLinkPreview/SwiftLinkPreview.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
-				"${BUILT_PRODUCTS_DIR}/TGPControls/TGPControls.framework",
-				"${BUILT_PRODUCTS_DIR}/Then/Then.framework",
-				"${BUILT_PRODUCTS_DIR}/YYText/YYText.framework",
-				"${BUILT_PRODUCTS_DIR}/YoutubePlayer-in-WKWebView/YoutubePlayer_in_WKWebView.framework",
-				"${BUILT_PRODUCTS_DIR}/reddift/reddift.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Slide for Reddit/Pods-Slide for Reddit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Anchorage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BadgeSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BiometricAuthentication.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DTCoreText.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DTFoundation.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Embassy.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/HTMLSpecialCharacters.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LicensesViewController.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MDFInternationalization.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MDFTextAccessibility.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MKColorPicker.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MTColorDistance.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MaterialComponents.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MiniKeychain.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MotionAnimator.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MotionInterchange.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpalImagePicker.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/QuickLayout.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RLBAlertsPickers.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDCAlertView.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SubtleVolume.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftEntryKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftLinkPreview.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TGPControls.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Then.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YYText.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YoutubePlayer_in_WKWebView.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/reddift.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Slide for Reddit/Pods-Slide for Reddit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2732,8 +2681,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
-					"\"SDWebImage\"",
-					"-framework",
 					"\"reddift\"",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-expression-type-checking=300 -Xfrontend -warn-long-function-bodies=300";
@@ -2773,8 +2720,6 @@
 				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					"-framework",
-					"\"SDWebImage\"",
 					"-framework",
 					"\"reddift\"",
 				);
@@ -3091,6 +3036,30 @@
 				minimumVersion = 5.4.0;
 			};
 		};
+		B4F333DF251273AF0032BB64 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.9.1;
+			};
+		};
+		B4F333E9251274050032BB64 /* XCRemoteSwiftPackageReference "swift-badge" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/evgenyneu/swift-badge";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.2;
+			};
+		};
+		B4F333F32512742E0032BB64 /* XCRemoteSwiftPackageReference "BiometricAuthentication" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rushisangani/BiometricAuthentication";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.1.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3103,6 +3072,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B4F333B725126FCE0032BB64 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = RealmSwift;
+		};
+		B4F333E0251273AF0032BB64 /* SDWebImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F333DF251273AF0032BB64 /* XCRemoteSwiftPackageReference "SDWebImage" */;
+			productName = SDWebImage;
+		};
+		B4F333EA251274050032BB64 /* BadgeSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F333E9251274050032BB64 /* XCRemoteSwiftPackageReference "swift-badge" */;
+			productName = BadgeSwift;
+		};
+		B4F333F42512742E0032BB64 /* BiometricAuthentication */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F333F32512742E0032BB64 /* XCRemoteSwiftPackageReference "BiometricAuthentication" */;
+			productName = BiometricAuthentication;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -54,6 +54,10 @@
 		B4F333E1251273AF0032BB64 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333E0251273AF0032BB64 /* SDWebImage */; };
 		B4F333EB251274050032BB64 /* BadgeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333EA251274050032BB64 /* BadgeSwift */; };
 		B4F333F52512742E0032BB64 /* BiometricAuthentication in Frameworks */ = {isa = PBXBuildFile; productRef = B4F333F42512742E0032BB64 /* BiometricAuthentication */; };
+		B4F3348B2512770F0032BB64 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = B4F3348A2512770F0032BB64 /* Embassy */; };
+		B4F3349F251277B80032BB64 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = B4F3349E251277B80032BB64 /* Starscream */; };
+		B4F3354C25127BAB0032BB64 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = B4F3354B25127BAB0032BB64 /* Anchorage */; };
+		B4F3355625127BD20032BB64 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = B4F3355525127BD20032BB64 /* Then */; };
 		B776B17D5CA92860424F37C0 /* ModQueueContributionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BA7C2B7217C3875F3BEC /* ModQueueContributionLoader.swift */; };
 		B776B1DF80711B443ED76B61 /* SettingsPro.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776B2AEE4A2438F5803329C /* SettingsPro.swift */; };
 		B776B1E23F4DEC18069F1579 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B776BC65995FE8D1EE75E2AB /* MediaViewController.swift */; };
@@ -816,12 +820,16 @@
 				B4F333B925126FCE0032BB64 /* Realm in Frameworks */,
 				B4F333F52512742E0032BB64 /* BiometricAuthentication in Frameworks */,
 				BEC2AB3A250D8D2C00AD5BEA /* WidgetKit.framework in Frameworks */,
+				B4F3355625127BD20032BB64 /* Then in Frameworks */,
 				B4F333E1251273AF0032BB64 /* SDWebImage in Frameworks */,
 				B4F333BB25126FCE0032BB64 /* RealmSwift in Frameworks */,
 				B4F333EB251274050032BB64 /* BadgeSwift in Frameworks */,
 				BE51BE6520C7386A00DFFD8B /* StoreKit.framework in Frameworks */,
+				B4F3354C25127BAB0032BB64 /* Anchorage in Frameworks */,
+				B4F3348B2512770F0032BB64 /* Embassy in Frameworks */,
 				BE2E9F0823492B4300FE07B4 /* CloudKit.framework in Frameworks */,
 				BE7BFB481F1997BA009CA2E1 /* MapKit.framework in Frameworks */,
+				B4F3349F251277B80032BB64 /* Starscream in Frameworks */,
 				01BBE6AB1AC863FE2E897632 /* Pods_Slide_for_Reddit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1539,6 +1547,10 @@
 				B4F333E0251273AF0032BB64 /* SDWebImage */,
 				B4F333EA251274050032BB64 /* BadgeSwift */,
 				B4F333F42512742E0032BB64 /* BiometricAuthentication */,
+				B4F3348A2512770F0032BB64 /* Embassy */,
+				B4F3349E251277B80032BB64 /* Starscream */,
+				B4F3354B25127BAB0032BB64 /* Anchorage */,
+				B4F3355525127BD20032BB64 /* Then */,
 			);
 			productName = "Slide for Reddit";
 			productReference = BE8FCA041E0C46090063B8EF /* Slide for Reddit.app */;
@@ -1705,6 +1717,10 @@
 				B4F333DF251273AF0032BB64 /* XCRemoteSwiftPackageReference "SDWebImage" */,
 				B4F333E9251274050032BB64 /* XCRemoteSwiftPackageReference "swift-badge" */,
 				B4F333F32512742E0032BB64 /* XCRemoteSwiftPackageReference "BiometricAuthentication" */,
+				B4F334892512770F0032BB64 /* XCRemoteSwiftPackageReference "Embassy" */,
+				B4F3349D251277B80032BB64 /* XCRemoteSwiftPackageReference "Starscream" */,
+				B4F3354A25127BAB0032BB64 /* XCRemoteSwiftPackageReference "Anchorage" */,
+				B4F3355425127BD20032BB64 /* XCRemoteSwiftPackageReference "Then" */,
 			);
 			productRefGroup = BE8FCA051E0C46090063B8EF /* Products */;
 			projectDirPath = "";
@@ -3060,6 +3076,38 @@
 				minimumVersion = 3.1.2;
 			};
 		};
+		B4F334892512770F0032BB64 /* XCRemoteSwiftPackageReference "Embassy" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/envoy/Embassy";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.1.1;
+			};
+		};
+		B4F3349D251277B80032BB64 /* XCRemoteSwiftPackageReference "Starscream" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/daltoniam/Starscream";
+			requirement = {
+				kind = exactVersion;
+				version = 3.1.1;
+			};
+		};
+		B4F3354A25127BAB0032BB64 /* XCRemoteSwiftPackageReference "Anchorage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Rightpoint/Anchorage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.4.0;
+			};
+		};
+		B4F3355425127BD20032BB64 /* XCRemoteSwiftPackageReference "Then" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/devxoul/Then";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3087,6 +3135,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B4F333F32512742E0032BB64 /* XCRemoteSwiftPackageReference "BiometricAuthentication" */;
 			productName = BiometricAuthentication;
+		};
+		B4F3348A2512770F0032BB64 /* Embassy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F334892512770F0032BB64 /* XCRemoteSwiftPackageReference "Embassy" */;
+			productName = Embassy;
+		};
+		B4F3349E251277B80032BB64 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F3349D251277B80032BB64 /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
+		};
+		B4F3354B25127BAB0032BB64 /* Anchorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F3354A25127BAB0032BB64 /* XCRemoteSwiftPackageReference "Anchorage" */;
+			productName = Anchorage;
+		};
+		B4F3355525127BD20032BB64 /* Then */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4F3355425127BD20032BB64 /* XCRemoteSwiftPackageReference "Then" */;
+			productName = Then;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -1523,10 +1523,10 @@
 				9B218AB4B7C97D4F5F5A194C /* [CP] Check Pods Manifest.lock */,
 				BE8FCA001E0C46090063B8EF /* Sources */,
 				BE8FCA011E0C46090063B8EF /* Frameworks */,
+				BE77470620366576006C72E8 /* Generate Credits.plist */,
 				BE8FCA021E0C46090063B8EF /* Resources */,
 				BE2B8A061E25BD220053D493 /* Embed Frameworks */,
 				BE0EF7D71F43F9C40058D572 /* Embed App Extensions */,
-				BE77470620366576006C72E8 /* Generate Credits.plist */,
 				0991C18B2108CDC600B6BA16 /* Run SwiftLint */,
 				0984BE512114C9490091C2E1 /* Integrate Reveal Server */,
 				BE20853621588F3B00D8F33C /* Embed Watch Content */,
@@ -1889,7 +1889,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "REVEAL_APP_PATH=$(mdfind kMDItemCFBundleIdentifier=\"com.ittybittyapps.Reveal2\" | head -n 1)\nBUILD_SCRIPT_PATH=\"${REVEAL_APP_PATH}/Contents/SharedSupport/Scripts/reveal_server_build_phase.sh\"\nif [ \"${REVEAL_APP_PATH}\" -a -e \"${BUILD_SCRIPT_PATH}\" ]; then\n    \"${BUILD_SCRIPT_PATH}\"\nelse\n    echo \"Reveal Server not loaded: Cannot find a compatible Reveal app.\"\nfi";
+			shellScript = "REVEAL_APP_PATH=$(mdfind kMDItemCFBundleIdentifier=\"com.ittybittyapps.Reveal2\" | head -n 1)\nBUILD_SCRIPT_PATH=\"${REVEAL_APP_PATH}/Contents/SharedSupport/Scripts/reveal_server_build_phase.sh\"\nif [ \"${REVEAL_APP_PATH}\" -a -e \"${BUILD_SCRIPT_PATH}\" ]; then\n    \"${BUILD_SCRIPT_PATH}\"\nelse\n    echo \"Reveal Server not loaded: Cannot find a compatible Reveal app.\"\nfi\n";
 		};
 		0991C18B2108CDC600B6BA16 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1903,7 +1903,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint";
+			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint\n";
 		};
 		6F3CE23C5F7990C228FD24D5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1988,7 +1988,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./credits.py -s \"$SRCROOT\" -o \"$SRCROOT/Slide for Reddit/Credits.plist\"";
+			shellScript = "# Search source directory and Swift Package Manager checkout directory for LICENSE files\n./credits.py -s \"$SRCROOT, $CONFIGURATION_BUILD_DIR/../../../SourcePackages/checkouts\" -o \"$SRCROOT/Slide for Reddit/Credits.plist\"\n";
 		};
 		BE85916B221BC9A7009ACF9E /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -2521,8 +2521,8 @@
 				DEVELOPMENT_TEAM = FTT89576VQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Open in Slide/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 5.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2738,8 +2738,8 @@
 				GCC_OPTIMIZATION_LEVEL = fast;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INFOPLIST_FILE = "Slide for Reddit/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "Anchorage",
+        "repositoryURL": "https://github.com/Rightpoint/Anchorage",
+        "state": {
+          "branch": null,
+          "revision": "18fed38e95db3200aecbd5b7101b981f91656084",
+          "version": "4.4.0"
+        }
+      },
+      {
         "package": "BiometricAuthentication",
         "repositoryURL": "https://github.com/rushisangani/BiometricAuthentication",
         "state": {
           "branch": null,
           "revision": "085569f12692a964ef580d4ec6e04956e879929a",
           "version": "3.1.2"
+        }
+      },
+      {
+        "package": "Embassy",
+        "repositoryURL": "https://github.com/envoy/Embassy",
+        "state": {
+          "branch": null,
+          "revision": "189436100c00efbf5fb2653fe7972a9371db0a91",
+          "version": "4.1.1"
         }
       },
       {
@@ -38,12 +56,39 @@
         }
       },
       {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream",
+        "state": {
+          "branch": null,
+          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
+          "version": "3.1.1"
+        }
+      },
+      {
         "package": "BadgeSwift",
         "repositoryURL": "https://github.com/evgenyneu/swift-badge",
         "state": {
           "branch": null,
           "revision": "f6cd330ed423556e909b7126b710c13ee23ccf45",
           "version": "8.0.2"
+        }
+      },
+      {
+        "package": "swift-nio-zlib-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
+        "state": {
+          "branch": null,
+          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "Then",
+        "repositoryURL": "https://github.com/devxoul/Then",
+        "state": {
+          "branch": null,
+          "revision": "e421a7b3440a271834337694e6050133a3958bc7",
+          "version": "2.7.0"
         }
       }
     ]

--- a/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "BiometricAuthentication",
+        "repositoryURL": "https://github.com/rushisangani/BiometricAuthentication",
+        "state": {
+          "branch": null,
+          "revision": "085569f12692a964ef580d4ec6e04956e879929a",
+          "version": "3.1.2"
+        }
+      },
+      {
         "package": "Realm",
         "repositoryURL": "https://github.com/realm/realm-cocoa.git",
         "state": {
@@ -17,6 +26,24 @@
           "branch": null,
           "revision": "34d7fbcbab2a94bcad081bddf9d172961cd84659",
           "version": "6.0.25"
+        }
+      },
+      {
+        "package": "SDWebImage",
+        "repositoryURL": "https://github.com/SDWebImage/SDWebImage",
+        "state": {
+          "branch": null,
+          "revision": "7a21432a370a34925046244462281bd36ebab73d",
+          "version": "5.9.1"
+        }
+      },
+      {
+        "package": "BadgeSwift",
+        "repositoryURL": "https://github.com/evgenyneu/swift-badge",
+        "state": {
+          "branch": null,
+          "revision": "f6cd330ed423556e909b7126b710c13ee23ccf45",
+          "version": "8.0.2"
         }
       }
     ]

--- a/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Realm",
+        "repositoryURL": "https://github.com/realm/realm-cocoa.git",
+        "state": {
+          "branch": null,
+          "revision": "6310911a38d55003f0b8acca96635aa2bfc3e2c0",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "RealmCore",
+        "repositoryURL": "https://github.com/realm/realm-core",
+        "state": {
+          "branch": null,
+          "revision": "34d7fbcbab2a94bcad081bddf9d172961cd84659",
+          "version": "6.0.25"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Slide for Reddit/Credits.plist
+++ b/Slide for Reddit/Credits.plist
@@ -506,22 +506,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>MIT License 
-
-Copyright (c) 2017 Rushi Sangani 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>BiometricAuthentication</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>Copyright (c) 2018 Xavier Schott 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
@@ -531,24 +515,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
 			<string>TGPControls</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License 
-
-Copyright (c) 2015 Evgenii Neumerzhitckii 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-</string>
-			<key>Title</key>
-			<string>BadgeSwift</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -849,14 +815,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
 			<string>MKColorPicker</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SDWebImage</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/Slide for Reddit/Credits.plist
+++ b/Slide for Reddit/Credits.plist
@@ -6,73 +6,423 @@
 	<array>
 		<dict>
 			<key>FooterText</key>
-			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+			<string>Copyright (c) 2014 Alamofire Software Foundation (http://alamofire.org/) 
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 
-   1. Definitions. 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
 
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
-
-   END OF TERMS AND CONDITIONS 
-
-   APPENDIX: How to apply the Apache License to your work. 
-
-      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
-
-   Copyright {yyyy} {name of copyright owner} 
-
-   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
-
-       http://www.apache.org/licenses/LICENSE-2.0 
-
-   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
-			<string>Slide-iOS</string>
+			<string>Alamofire</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Rightpoint 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Anchorage</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License 
+
+Copyright (c) 2017 Rushi Sangani 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>BiometricAuthentication</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 Carthage contributors 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Commandant</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 Carthage contributors 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Commandant</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 Carthage contributors 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Commandant</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 Carthage contributors 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Commandant</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlCatchException</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>ISC License 
+
+Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved. 
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</string>
+			<key>Title</key>
+			<string>CwlPreconditionTesting</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2011, Oliver Drobnik All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+- Redistributions of source code must retain the above copyright notice, this   list of conditions and the following disclaimer.  
+
+- Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
+			<key>Title</key>
+			<string>DTCoreText</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2011, Oliver Drobnik All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+- Redistributions of source code must retain the above copyright notice, this   list of conditions and the following disclaimer.  
+
+- Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
+			<key>Title</key>
+			<string>DTFoundation</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Outrageous Labs, Inc 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Embassy</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -94,127 +444,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>The MIT License (MIT) 
+			<string>credits.py 
 
-Copyright (c) 2017 Ruoyu Fu 
+The MIT License (MIT) 
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SwiftyJSON</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright (c) 2014 Alamofire Software Foundation (http://alamofire.org/) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Alamofire</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
-
-   END OF TERMS AND CONDITIONS 
-
-   APPENDIX: How to apply the Apache License to your work. 
-
-      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "[]"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
-
-   Copyright [yyyy] [name of copyright owner] 
-
-   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
-
-       http://www.apache.org/licenses/LICENSE-2.0 
-
-   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
-			<key>Title</key>
-			<string>MotionInterchange</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>MIT License 
-
-Copyright (c) 2018 Daniel Huri, huri000@gmail.com 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SwiftEntryKit</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Leonardo Cardoso 
+Copyright (c) 2014 Carlo Eugster (https://github.com/carloe) 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 
@@ -224,41 +458,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </string>
 			<key>Title</key>
-			<string>SwiftLinkPreview</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2013 Scott Berrevoets 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-</string>
-			<key>Title</key>
-			<string>SDCAlertView</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>MIT License 
-
-Copyright (c) 2017 opalorange 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>OpalImagePicker</string>
+			<string>LicensesViewController</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -336,74 +536,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>credits.py 
-
-The MIT License (MIT) 
-
-Copyright (c) 2014 Carlo Eugster (https://github.com/carloe) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-</string>
-			<key>Title</key>
-			<string>LicensesViewController</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2015 ibireme &lt;ibireme@gmail.com&gt; 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>YYText</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Andrea Mazzini 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SubtleVolume</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2020 Realm Inc. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SwiftLint</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
@@ -476,7 +608,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2017 huri000@gmail.com &lt;huri000@gmail.com&gt; 
+			<string>Copyright (c) 2017 malkouz moayad_kouz9@hotmail.com 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 
@@ -484,13 +616,13 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
-			<string>QuickLayout</string>
+			<string>MKColorPicker</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2018 Xavier Schott 
+			<string>Copyright (c) 2010 Mysterious Trousers, LLC (http://www.mysterioustrousers.com) 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 
@@ -498,39 +630,7 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
-			<string>TGPControls</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2015 sonson 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>reddift</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright (c) 2011, Oliver Drobnik All rights reserved. 
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
-
-- Redistributions of source code must retain the above copyright notice, this   list of conditions and the following disclaimer.  
-
-- Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
-			<key>Title</key>
-			<string>DTCoreText</string>
+			<string>MTColorDistance</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -608,17 +708,31 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2011, Oliver Drobnik All rights reserved. 
+			<string>reddift 
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+MIT License 
 
-- Redistributions of source code must retain the above copyright notice, this   list of conditions and the following disclaimer.  
+Copyright (c) 2016 sonson 
 
-- Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+
+KeychainAccess 
+
+The MIT License (MIT) 
+
+Copyright (c) 2014 kishikawa katsumi 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
-			<string>DTFoundation</string>
+			<string>MiniKeychain</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -696,216 +810,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2017 malkouz moayad_kouz9@hotmail.com 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>MKColorPicker</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2020 Realm Inc. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SwiftLint</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2018 Roman Volodko &lt;roman.volodko@gmail.com&gt; 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>RLBAlertsPickers</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright 2014 Google Inc. All rights reserved. 
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at 
-
-    http://www.apache.org/licenses/LICENSE-2.0 
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-</string>
-			<key>Title</key>
-			<string>YoutubePlayer-in-WKWebView</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>reddift 
-
-MIT License 
-
-Copyright (c) 2016 sonson 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
-
-KeychainAccess 
-
-The MIT License (MIT) 
-
-Copyright (c) 2014 kishikawa katsumi 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>MiniKeychain</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright (c) 2010 Mysterious Trousers, LLC (http://www.mysterioustrousers.com) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>MTColorDistance</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2015 Suyeol Jeon (xoul.kr) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Then</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>TABLE OF CONTENTS 
-
-1. Apache License version 2.0 2. Export Compliance 
-
-------------------------------------------------------------------------------- 
-
-                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
-
-   END OF TERMS AND CONDITIONS 
-
-EXPORT COMPLIANCE 
-
-You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
-
-You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
-			<key>Title</key>
-			<string>realm-core</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2007-2018 Dr. Colin Hirsch and Daniel Frey 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>pegtl</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
@@ -972,155 +876,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
    Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
 			<key>Title</key>
-			<string>swift-nio-zlib-support</string>
+			<string>MotionInterchange</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>MIT License 
-
-Copyright (c) 2017 Rushi Sangani 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>BiometricAuthentication</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Outrageous Labs, Inc 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Embassy</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>                              Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   Copyright (c) 2014-2016 Dalton Cherry. 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability.
-
-</string>
-			<key>Title</key>
-			<string>Starscream</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Rightpoint 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Anchorage</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License 
-
-Copyright (c) 2015 Evgenii Neumerzhitckii 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-</string>
-			<key>Title</key>
-			<string>swift-badge</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>SDWebImage</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>TABLE OF CONTENTS 
-
-1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
-
-1. ------------------------------------------------------------------------------- 
-
-                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 
@@ -1172,37 +934,669 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
    9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
 
-2. ------------------------------------------------------------------------------- 
+   END OF TERMS AND CONDITIONS 
 
-REALM COMPONENTS 
+   APPENDIX: How to apply the Apache License to your work. 
 
-This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
 
-For the Realm Platform Extensions component 
+   Copyright 2016 Quick Team 
 
-  Realm Platform Extensions License 
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
 
-  Copyright (c) 2011-2017 Realm Inc All rights reserved 
+       http://www.apache.org/licenses/LICENSE-2.0 
 
-  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
-
-  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
-
-  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
-
-  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
-
-3. ------------------------------------------------------------------------------- 
-
-EXPORT COMPLIANCE 
-
-You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
-
-You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
 			<key>Title</key>
-			<string>realm-cocoa</string>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2016 Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Nimble</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -1312,6 +1706,908 @@ You agree to comply with all export, re-export and import restrictions and regul
 		</dict>
 		<dict>
 			<key>FooterText</key>
+			<string>MIT License 
+
+Copyright (c) 2017 opalorange 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>OpalImagePicker</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2014, Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Quick</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2014, Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Quick</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2014, Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Quick</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2014, Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Quick</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright 2014, Quick Team 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Quick</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2017 huri000@gmail.com &lt;huri000@gmail.com&gt; 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>QuickLayout</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2018 Roman Volodko &lt;roman.volodko@gmail.com&gt; 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>RLBAlertsPickers</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2013 Scott Berrevoets 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</string>
+			<key>Title</key>
+			<string>SDCAlertView</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SDWebImage</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2014 David Mohundro   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SWXMLHash</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2014 David Mohundro   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SWXMLHash</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2014 David Mohundro   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SWXMLHash</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2014 David Mohundro   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SWXMLHash</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright {yyyy} {name of copyright owner} 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>Slide-iOS</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SourceKitten</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2014 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SourceKitten</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>                              Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   Copyright (c) 2014-2016 Dalton Cherry. 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability.
+
+</string>
+			<key>Title</key>
+			<string>Starscream</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Andrea Mazzini 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SubtleVolume</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License 
+
+Copyright (c) 2018 Daniel Huri, huri000@gmail.com 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftEntryKit</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Leonardo Cardoso 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</string>
+			<key>Title</key>
+			<string>SwiftLinkPreview</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2020 Realm Inc. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2020 Realm Inc. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2020 Realm Inc. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2017 Ruoyu Fu 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftyJSON</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Scott Hoyt 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftyTextTable</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Scott Hoyt 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftyTextTable</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2018 Xavier Schott 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>TGPControls</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2015 Suyeol Jeon (xoul.kr) 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Then</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2015 ibireme &lt;ibireme@gmail.com&gt; 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>YYText</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Yams</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Yams</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Yams</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 JP Simard. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Yams</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright 2014 Google Inc. All rights reserved. 
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+</string>
+			<key>Title</key>
+			<string>YoutubePlayer-in-WKWebView</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
 			<string>Boost Software License - Version 1.0 - August 17th, 2003 
 
 Permission is hereby granted, free of charge, to any person or organization obtaining a copy of the software and accompanying documentation covered by this license (the "Software") to use, reproduce, display, distribute, execute, and transmit the Software, and to prepare derivative works of the Software, and to permit third-parties to whom the Software is furnished to do so, all subject to the following: 
@@ -1321,6 +2617,336 @@ The copyright notices in the Software and this entire statement, including the a
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
 			<string>catch</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2007-2018 Dr. Colin Hirsch and Daniel Frey 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>pegtl</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>TABLE OF CONTENTS 
+
+1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
+
+1. ------------------------------------------------------------------------------- 
+
+                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+2. ------------------------------------------------------------------------------- 
+
+REALM COMPONENTS 
+
+This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
+
+For the Realm Platform Extensions component 
+
+  Realm Platform Extensions License 
+
+  Copyright (c) 2011-2017 Realm Inc All rights reserved 
+
+  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
+
+  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
+
+  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+
+  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
+
+3. ------------------------------------------------------------------------------- 
+
+EXPORT COMPLIANCE 
+
+You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
+
+You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
+			<key>Title</key>
+			<string>realm-cocoa</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>TABLE OF CONTENTS 
+
+1. Apache License version 2.0 2. Export Compliance 
+
+------------------------------------------------------------------------------- 
+
+                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+EXPORT COMPLIANCE 
+
+You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
+
+You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
+			<key>Title</key>
+			<string>realm-core</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2015 sonson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>reddift</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>**Copyright (c) 2013 Justin Spahr-Summers** 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>script</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>**Copyright (c) 2013 Justin Spahr-Summers** 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>script</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>**Copyright (c) 2013 Justin Spahr-Summers** 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>script</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License 
+
+Copyright (c) 2015 Evgenii Neumerzhitckii 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</string>
+			<key>Title</key>
+			<string>swift-badge</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "[]"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright [yyyy] [name of copyright owner] 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>swift-nio-zlib-support</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/Slide for Reddit/Credits.plist
+++ b/Slide for Reddit/Credits.plist
@@ -800,6 +800,530 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2015 Suyeol Jeon (xoul.kr) 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Then</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>TABLE OF CONTENTS 
+
+1. Apache License version 2.0 2. Export Compliance 
+
+------------------------------------------------------------------------------- 
+
+                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+EXPORT COMPLIANCE 
+
+You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
+
+You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
+			<key>Title</key>
+			<string>realm-core</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2007-2018 Dr. Colin Hirsch and Daniel Frey 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>pegtl</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "[]"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright [yyyy] [name of copyright owner] 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
+			<key>Title</key>
+			<string>swift-nio-zlib-support</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License 
+
+Copyright (c) 2017 Rushi Sangani 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>BiometricAuthentication</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Outrageous Labs, Inc 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Embassy</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>                              Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   Copyright (c) 2014-2016 Dalton Cherry. 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability.
+
+</string>
+			<key>Title</key>
+			<string>Starscream</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2016 Rightpoint 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>Anchorage</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License 
+
+Copyright (c) 2015 Evgenii Neumerzhitckii 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</string>
+			<key>Title</key>
+			<string>swift-badge</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SDWebImage</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>TABLE OF CONTENTS 
+
+1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
+
+1. ------------------------------------------------------------------------------- 
+
+                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+2. ------------------------------------------------------------------------------- 
+
+REALM COMPONENTS 
+
+This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
+
+For the Realm Platform Extensions component 
+
+  Realm Platform Extensions License 
+
+  Copyright (c) 2011-2017 Realm Inc All rights reserved 
+
+  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
+
+  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
+
+  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+
+  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
+
+3. ------------------------------------------------------------------------------- 
+
+EXPORT COMPLIANCE 
+
+You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
+
+You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
+			<key>Title</key>
+			<string>realm-cocoa</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>TABLE OF CONTENTS 
+
+1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
+
+------------------------------------------------------------------------------- 
+
+                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+   1. Definitions. 
+
+      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
+
+      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
+
+      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
+
+      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
+
+      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
+
+      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
+
+      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
+
+      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
+
+      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
+
+   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
+
+   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
+
+      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
+
+      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
+
+      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
+
+      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
+
+      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
+
+   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
+
+   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
+
+   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
+
+   END OF TERMS AND CONDITIONS 
+
+   APPENDIX: How to apply the Apache License to your work. 
+
+      To apply the Apache License to your work, attach the following       boilerplate notice, with the fields enclosed by brackets "{}"       replaced with your own identifying information. (Don't include       the brackets!)  The text should be enclosed in the appropriate       comment syntax for the file format. We also recommend that a       file or class name and description of purpose be included on the       same "printed page" as the copyright notice for easier       identification within third-party archives. 
+
+   Copyright {yyyy} {name of copyright owner} 
+
+   Licensed under the Apache License, Version 2.0 (the "License");    you may not use this file except in compliance with the License.    You may obtain a copy of the License at 
+
+       http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License. 
+
+REALM COMPONENTS 
+
+This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
+
+For the Realm Core component 
+
+  Realm Core Binary License 
+
+  Copyright (c) 2011-2016 Realm Inc All rights reserved 
+
+  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
+
+  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
+
+  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
+
+  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
+
+EXPORT COMPLIANCE 
+
+You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not located in a country that is subject to United States export restriction or embargo, including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, and that you are not on the Department of Commerce list of Denied Persons, Unverified Parties, or affiliated with a Restricted Entity. 
+
+You agree to comply with all export, re-export and import restrictions and regulations of the Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, the Software to any prohibited country, including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, or to any person or organization on or affiliated with the Department of Commerce lists of Denied Persons, Unverified Parties or Restricted Entities, or otherwise in violation of any such restrictions or regulations.</string>
+			<key>Title</key>
+			<string>ObjectStore</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>Boost Software License - Version 1.0 - August 17th, 2003 
+
+Permission is hereby granted, free of charge, to any person or organization obtaining a copy of the software and accompanying documentation covered by this license (the "Software") to use, reproduce, display, distribute, execute, and transmit the Software, and to prepare derivative works of the Software, and to permit third-parties to whom the Software is furnished to do so, all subject to the following: 
+
+The copyright notices in the Software and this entire statement, including the above license grant, this restriction and the following disclaimer, must be included in all copies of the Software, in whole or in part, and all derivative works of the Software, unless such copies or derivative works are solely in the form of machine-executable object code generated by a source language processor. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>catch</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
 	</array>
 	<key>StringsTable</key>
 	<string>Acknowledgements</string>

--- a/Slide for Reddit/Credits.plist
+++ b/Slide for Reddit/Credits.plist
@@ -196,22 +196,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2015 Suyeol Jeon (xoul.kr) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Then</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>MIT License 
 
 Copyright (c) 2018 Daniel Huri, huri000@gmail.com 
@@ -536,22 +520,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Outrageous Labs, Inc 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Embassy</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>Copyright (c) 2011, Oliver Drobnik All rights reserved. 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
@@ -563,68 +531,6 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
 			<key>Title</key>
 			<string>DTCoreText</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>                              Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   Copyright (c) 2014-2016 Dalton Cherry. 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability.
-
-</string>
-			<key>Title</key>
-			<string>Starscream</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -697,22 +603,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
    Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
 			<key>Title</key>
 			<string>MaterialComponents</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>The MIT License (MIT) 
-
-Copyright (c) 2016 Rightpoint 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
-			<key>Title</key>
-			<string>Anchorage</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/Slide for Reddit/Credits.plist
+++ b/Slide for Reddit/Credits.plist
@@ -72,7 +72,7 @@
 
    Unless required by applicable law or agreed to in writing, software    distributed under the License is distributed on an "AS IS" BASIS,    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    See the License for the specific language governing permissions and    limitations under the License.</string>
 			<key>Title</key>
-			<string>Slide-ios</string>
+			<string>Slide-iOS</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -388,100 +388,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>TABLE OF CONTENTS 
-
-1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
-
-1. ------------------------------------------------------------------------------- 
-
-                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
-
-2. ------------------------------------------------------------------------------- 
-
-REALM COMPONENTS 
-
-This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
-
-For the Realm Platform Extensions component 
-
-  Realm Platform Extensions License 
-
-  Copyright (c) 2011-2017 Realm Inc All rights reserved 
-
-  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
-
-  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
-
-  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
-
-  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
-
-3. ------------------------------------------------------------------------------- 
-
-EXPORT COMPLIANCE 
-
-You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
-
-You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
-			<key>Title</key>
-			<string>RealmSwift</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
 			<string>The MIT License (MIT) 
 
 Copyright (c) 2016 Andrea Mazzini 
@@ -493,6 +399,22 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
 			<string>SubtleVolume</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>The MIT License (MIT) 
+
+Copyright (c) 2020 Realm Inc. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
@@ -967,100 +889,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
 			<key>Title</key>
 			<string>RLBAlertsPickers</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>FooterText</key>
-			<string>TABLE OF CONTENTS 
-
-1. Apache License version 2.0 2. Realm Components 3. Export Compliance 
-
-1. ------------------------------------------------------------------------------- 
-
-                                 Apache License                            Version 2.0, January 2004                         http://www.apache.org/licenses/ 
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
-
-   1. Definitions. 
-
-      "License" shall mean the terms and conditions for use, reproduction,       and distribution as defined by Sections 1 through 9 of this document. 
-
-      "Licensor" shall mean the copyright owner or entity authorized by       the copyright owner that is granting the License. 
-
-      "Legal Entity" shall mean the union of the acting entity and all       other entities that control, are controlled by, or are under common       control with that entity. For the purposes of this definition,       "control" means (i) the power, direct or indirect, to cause the       direction or management of such entity, whether by contract or       otherwise, or (ii) ownership of fifty percent (50%) or more of the       outstanding shares, or (iii) beneficial ownership of such entity. 
-
-      "You" (or "Your") shall mean an individual or Legal Entity       exercising permissions granted by this License. 
-
-      "Source" form shall mean the preferred form for making modifications,       including but not limited to software source code, documentation       source, and configuration files. 
-
-      "Object" form shall mean any form resulting from mechanical       transformation or translation of a Source form, including but       not limited to compiled object code, generated documentation,       and conversions to other media types. 
-
-      "Work" shall mean the work of authorship, whether in Source or       Object form, made available under the License, as indicated by a       copyright notice that is included in or attached to the work       (an example is provided in the Appendix below). 
-
-      "Derivative Works" shall mean any work, whether in Source or Object       form, that is based on (or derived from) the Work and for which the       editorial revisions, annotations, elaborations, or other modifications       represent, as a whole, an original work of authorship. For the purposes       of this License, Derivative Works shall not include works that remain       separable from, or merely link (or bind by name) to the interfaces of,       the Work and Derivative Works thereof. 
-
-      "Contribution" shall mean any work of authorship, including       the original version of the Work and any modifications or additions       to that Work or Derivative Works thereof, that is intentionally       submitted to Licensor for inclusion in the Work by the copyright owner       or by an individual or Legal Entity authorized to submit on behalf of       the copyright owner. For the purposes of this definition, "submitted"       means any form of electronic, verbal, or written communication sent       to the Licensor or its representatives, including but not limited to       communication on electronic mailing lists, source code control systems,       and issue tracking systems that are managed by, or on behalf of, the       Licensor for the purpose of discussing and improving the Work, but       excluding communication that is conspicuously marked or otherwise       designated in writing by the copyright owner as "Not a Contribution." 
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity       on behalf of whom a Contribution has been received by Licensor and       subsequently incorporated within the Work. 
-
-   2. Grant of Copyright License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       copyright license to reproduce, prepare Derivative Works of,       publicly display, publicly perform, sublicense, and distribute the       Work and such Derivative Works in Source or Object form. 
-
-   3. Grant of Patent License. Subject to the terms and conditions of       this License, each Contributor hereby grants to You a perpetual,       worldwide, non-exclusive, no-charge, royalty-free, irrevocable       (except as stated in this section) patent license to make, have made,       use, offer to sell, sell, import, and otherwise transfer the Work,       where such license applies only to those patent claims licensable       by such Contributor that are necessarily infringed by their       Contribution(s) alone or by combination of their Contribution(s)       with the Work to which such Contribution(s) was submitted. If You       institute patent litigation against any entity (including a       cross-claim or counterclaim in a lawsuit) alleging that the Work       or a Contribution incorporated within the Work constitutes direct       or contributory patent infringement, then any patent licenses       granted to You under this License for that Work shall terminate       as of the date such litigation is filed. 
-
-   4. Redistribution. You may reproduce and distribute copies of the       Work or Derivative Works thereof in any medium, with or without       modifications, and in Source or Object form, provided that You       meet the following conditions: 
-
-      (a) You must give any other recipients of the Work or           Derivative Works a copy of this License; and 
-
-      (b) You must cause any modified files to carry prominent notices           stating that You changed the files; and 
-
-      (c) You must retain, in the Source form of any Derivative Works           that You distribute, all copyright, patent, trademark, and           attribution notices from the Source form of the Work,           excluding those notices that do not pertain to any part of           the Derivative Works; and 
-
-      (d) If the Work includes a "NOTICE" text file as part of its           distribution, then any Derivative Works that You distribute must           include a readable copy of the attribution notices contained           within such NOTICE file, excluding those notices that do not           pertain to any part of the Derivative Works, in at least one           of the following places: within a NOTICE text file distributed           as part of the Derivative Works; within the Source form or           documentation, if provided along with the Derivative Works; or,           within a display generated by the Derivative Works, if and           wherever such third-party notices normally appear. The contents           of the NOTICE file are for informational purposes only and           do not modify the License. You may add Your own attribution           notices within Derivative Works that You distribute, alongside           or as an addendum to the NOTICE text from the Work, provided           that such additional attribution notices cannot be construed           as modifying the License. 
-
-      You may add Your own copyright statement to Your modifications and       may provide additional or different license terms and conditions       for use, reproduction, or distribution of Your modifications, or       for any such Derivative Works as a whole, provided Your use,       reproduction, and distribution of the Work otherwise complies with       the conditions stated in this License. 
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,       any Contribution intentionally submitted for inclusion in the Work       by You to the Licensor shall be under the terms and conditions of       this License, without any additional terms or conditions.       Notwithstanding the above, nothing herein shall supersede or modify       the terms of any separate license agreement you may have executed       with Licensor regarding such Contributions. 
-
-   6. Trademarks. This License does not grant permission to use the trade       names, trademarks, service marks, or product names of the Licensor,       except as required for reasonable and customary use in describing the       origin of the Work and reproducing the content of the NOTICE file. 
-
-   7. Disclaimer of Warranty. Unless required by applicable law or       agreed to in writing, Licensor provides the Work (and each       Contributor provides its Contributions) on an "AS IS" BASIS,       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       implied, including, without limitation, any warranties or conditions       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A       PARTICULAR PURPOSE. You are solely responsible for determining the       appropriateness of using or redistributing the Work and assume any       risks associated with Your exercise of permissions under this License. 
-
-   8. Limitation of Liability. In no event and under no legal theory,       whether in tort (including negligence), contract, or otherwise,       unless required by applicable law (such as deliberate and grossly       negligent acts) or agreed to in writing, shall any Contributor be       liable to You for damages, including any direct, indirect, special,       incidental, or consequential damages of any character arising as a       result of this License or out of the use or inability to use the       Work (including but not limited to damages for loss of goodwill,       work stoppage, computer failure or malfunction, or any and all       other commercial damages or losses), even if such Contributor       has been advised of the possibility of such damages. 
-
-   9. Accepting Warranty or Additional Liability. While redistributing       the Work or Derivative Works thereof, You may choose to offer,       and charge a fee for, acceptance of support, warranty, indemnity,       or other liability obligations and/or rights consistent with this       License. However, in accepting such obligations, You may act only       on Your own behalf and on Your sole responsibility, not on behalf       of any other Contributor, and only if You agree to indemnify,       defend, and hold each Contributor harmless for any liability       incurred by, or claims asserted against, such Contributor by reason       of your accepting any such warranty or additional liability. 
-
-2. ------------------------------------------------------------------------------- 
-
-REALM COMPONENTS 
-
-This software contains components with separate copyright and license terms. Your use of these components is subject to the terms and conditions of the following licenses. 
-
-For the Realm Platform Extensions component 
-
-  Realm Platform Extensions License 
-
-  Copyright (c) 2011-2017 Realm Inc All rights reserved 
-
-  Redistribution and use in binary form, with or without modification, is   permitted provided that the following conditions are met: 
-
-  1. You agree not to attempt to decompile, disassemble, reverse engineer or   otherwise discover the source code from which the binary code was derived.   You may, however, access and obtain a separate license for most of the   source code from which this Software was created, at   http://realm.io/pricing/. 
-
-  2. Redistributions in binary form must reproduce the above copyright notice,   this list of conditions and the following disclaimer in the documentation   and/or other materials provided with the distribution. 
-
-  3. Neither the name of the copyright holder nor the names of its   contributors may be used to endorse or promote products derived from this   software without specific prior written permission. 
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   POSSIBILITY OF SUCH DAMAGE. 
-
-3. ------------------------------------------------------------------------------- 
-
-EXPORT COMPLIANCE 
-
-You understand that the Software may contain cryptographic functions that may be subject to export restrictions, and you represent and warrant that you are not (i) located in a jurisdiction that is subject to United States economic sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea, Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government blacklist (to include the List of Specially Designated Nationals and Blocked Persons or the Consolidated Sanctions List administered by the U.S. Department of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List or Entity List administered by the U.S. Department of Commerce) (“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned Person. 
-
-You agree to comply with all export, re-export and import restrictions and regulations of the U.S. Department of Commerce or other agency or authority of the United States or other applicable countries. You also agree not to transfer, or authorize the transfer of, directly or indirectly, of the Software to any Prohibited Jurisdiction, or otherwise in violation of any such restrictions or regulations.</string>
-			<key>Title</key>
-			<string>Realm</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/credits.py
+++ b/credits.py
@@ -21,9 +21,12 @@ from optparse import OptionParser
 from optparse import Option, OptionValueError
 from copy import deepcopy
 
-VERSION = '0.3' # NOTE: Jon modified v0.3 to make this source. We should put in a PR after rebasing our changes off of their latest version.
+VERSION = '0.5.0'
 PROG = os.path.basename(os.path.splitext(__file__)[0])
-DESCRIPTION = '''Recursively searches the input directory for 'LICENSE.*' files and compiles them into a Settings.bundle friendly plist. Inspired by JosephH and Sean's comments on stackoverflow: http://stackoverflow.com/q/6428353'''
+DESCRIPTION = """Generate a `Settings.bundle` friendly plist file from all
+ 'LICENSE.*' files in a given directory. Inspired by JosephH and Sean's
+ comments on stackoverflow: http://stackoverflow.com/q/6428353"""
+
 
 class MultipleOption(Option):
     ACTIONS = Option.ACTIONS + ("extend",)
@@ -38,96 +41,126 @@ class MultipleOption(Option):
             Option.take_action(self, action, dest, opt, value, values, parser)
 
 
-def main(argv):
-    def list_callback(option, opt, value, parser):
-        setattr(parser.values, option.dest, [item.strip() for item in value.split(',')])
+def main(_):
+    def list_callback(option, _, value, option_parser):
+        setattr(option_parser.values, option.dest, [item.strip() for item in value.split(',')])
 
     parser = OptionParser(option_class=MultipleOption,
-                              usage='usage: %prog -s source_path -o output_plist -e [exclude_paths]',
-                              version='%s %s' % (PROG, VERSION),
-                              description=DESCRIPTION)
-    parser.add_option('-s', '--source', 
-                   action="callback", type="string",
-                  dest='inputpaths', 
-                  metavar='source_path', 
-                  help='comma separated list of directories to recursively search for licenses',
-                  callback=list_callback)
-    parser.add_option('-o', '--output-plist', 
-                   type="string",
-                  dest='outputfile', 
-                  metavar='output_plist', 
-                  help='path to the plist to be generated')
-    parser.add_option('-e', '--exclude', 
-                  action="callback", type="string",
-                  dest='excludes', 
-                  metavar='path1, ...', 
-                  help='comma separated list of paths to be excluded',
-                  callback=list_callback)
+                          usage='usage: %prog -s source_path -o output_plist -e [exclude_paths]',
+                          version='%s %s' % (PROG, VERSION),
+                          description=DESCRIPTION)
+    parser.add_option('-s', '--source',
+                      action="callback", type="string",
+                      dest='input_path',
+                      metavar='source_path',
+                      help='comma separated list of directories to recursively search for licenses',
+                      callback=list_callback)
+    parser.add_option('-o', '--output-plist',
+                      type="string",
+                      dest='output_file',
+                      metavar='output_plist',
+                      help='path to the plist to be generated')
+    parser.add_option('-e', '--exclude',
+                      action="callback", type="string",
+                      dest='excludes',
+                      metavar='path1, ...',
+                      help='comma separated list of paths to be excluded',
+                      callback=list_callback)
+    parser.add_option('-t', '--test',
+                      action="store_true",
+                      dest='include_tests',
+                      metavar='include_tests',
+                      default=False,
+                      help='include files in the `Tests` directory for unit testing')
     if len(sys.argv) == 1:
         parser.parse_args(['--help'])
 
-    OPTIONS, args = parser.parse_args()
+    options, args = parser.parse_args()
 
-    for inputpath in OPTIONS.inputpaths:
-        if(not os.path.isdir(inputpath)):
-            print "Error: Source path does not exist: %s" % inputpath
+    print options.input_path
+    for path in options.input_path:
+        if(not os.path.isdir(path)):
+            print "Error: Source path does not exist: %s" % path
             sys.exit(2)
 
-    if(not OPTIONS.outputfile.endswith('.plist')):
-        print "Error: Outputfile must end in .plist"
+    if not options.output_file.endswith('.plist'):
+        print("Error: Outputfile must end in .plist")
         sys.exit(2)
 
-    plist = plistFromDirs(OPTIONS.inputpaths, OPTIONS.excludes)
-    plistlib.writePlist(plist,OPTIONS.outputfile)
+    plist = plist_from_dirs(
+        options.input_path,
+        options.excludes,
+        options.include_tests
+    )
+    plistlib.writePlist(plist, options.output_file)
     return 0
 
-def plistFromDirs(dirs, excludes):
+
+def plist_from_dirs(directories, excludes, include_tests):
     """
-    Recursively searches each directory in 'dirs' and generate plists objects 
+    Recursively searches each directory in 'directories' and generate plists objects 
     from any LICENSE files found.
     """
     plist = {'PreferenceSpecifiers': [], 'StringsTable': 'Acknowledgements'}
-    os.chdir(sys.path[0])
-    for dir in dirs:
-        for root, dirs, files in os.walk(dir):
-            for file in files:
-                if file.startswith("LICENSE"):
-                    plistPath = os.path.join(root, file)
-                    if not excludePath(plistPath, excludes):
-                        license = plistFromFile(plistPath)
-                        plist['PreferenceSpecifiers'].append(license)
+    for directory in directories:
+        license_paths = license_paths_from_dir(directory)
+        plist_paths = (plist_path for plist_path in license_paths if not exclude_path(plist_path, excludes, include_tests))
+        for plist_path in plist_paths:
+            license_dict = plist_from_file(plist_path)
+            plist['PreferenceSpecifiers'].append(license_dict)
+
+    plist['PreferenceSpecifiers'] = sorted(plist['PreferenceSpecifiers'], key=lambda x: x['Title'])
     return plist
 
-def plistFromFile(path):
+
+def license_paths_from_dir(directory):
+    return_dict = []
+    os.chdir(sys.path[0])
+    for dir_path, _, file_names in os.walk(directory):
+        file_names = (file_name for file_name in file_names if file_name.startswith("LICENSE"))
+        for file_name in file_names:
+            return_dict.append(os.path.join(dir_path, file_name))
+    return return_dict
+
+
+def plist_from_file(path):
     """
     Returns a plist representation of the file at 'path'. Uses the name of the
-    paremt folder for the title property.
+    parent folder for the title property.
     """
     base_group = {'Type': 'PSGroupSpecifier', 'FooterText': '', 'Title': ''}
     current_file = open(path, 'r')
     group = deepcopy(base_group)
     title = path.split("/")[-2]
     group['Title'] = unicode(title, 'utf-8')
-    srcBody = current_file.read()
+    src_body = current_file.read()
     body = ""
-    for match in re.finditer(r'(?s)((?:[^\n][\n]?)+)', srcBody):
+    for match in re.finditer(r'(?s)((?:[^\n][\n]?)+)', src_body):
         body = body + re.sub("(\\n)", " ", match.group()) + "\n\n"
     body = unicode(body, 'utf-8')
     group['FooterText'] = rchop(body, " \n\n")
     return group
-    
-def excludePath(path, excludes):
-    if excludes is None:
+
+
+def exclude_path(path, excludes, is_testing):
+    if "/LicenseGenerator-iOS/Example/" in path:
+        return True
+    elif "/LicenseGenerator-iOS/Tests/" in path:
+        return not is_testing
+    elif excludes is None:
         return False
+
     for pattern in excludes:
-        if(re.search(pattern.strip(), path, re.S) != None):
+        if re.search(pattern.strip(), path, re.S) is not None:
             return True
     return False
-    
+
+
 def rchop(str, ending):
     if str.endswith(ending):
         return str[:-len(ending)]
     return str
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
This PR moves as many dependencies as we can from Cocoapods to Swift Package Manager.

Really I just wanted to move Realm, because it was breaking our SwiftUI previews. So that's fixed now. I figured I'd keep going.

### Moved:
* SDWebImage
* BadgeSwift
* BiometricAuthentication
* Embassy
* Starscream (forced to 3.1.1, newest version has breaking changes)
* RealmSwift
* Anchorage
* Then

### Problems:
* OpalImagePicker and SubtleVolume have SPM integrations, but they're out of date and won't import. 
* AlamoFire can import, but we'd need to update to support 5.X instead of 4.X. 
* DTCoreText supports SPM as of 23 days ago, but it fails to compile. I've logged the issue [here](https://github.com/Cocoanetics/DTCoreText/issues/1204).