### PR TITLE
Performance Improvements and New Text Rendering

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,39 +19,39 @@ PODS:
     - DTFoundation/Core
   - HTMLSpecialCharacters (1.3.6)
   - LicensesViewController (0.7.0)
-  - MaterialComponents/ActivityIndicator (118.1.0):
+  - MaterialComponents/ActivityIndicator (119.1.0):
     - MaterialComponents/Palettes
     - MaterialComponents/private/Application
     - MDFInternationalization
     - MotionAnimator (~> 2.0)
-  - MaterialComponents/AnimationTiming (118.1.0)
-  - MaterialComponents/Availability (118.1.0)
-  - MaterialComponents/Elevation (118.1.0):
+  - MaterialComponents/AnimationTiming (119.1.0)
+  - MaterialComponents/Availability (119.1.0)
+  - MaterialComponents/Elevation (119.1.0):
     - MaterialComponents/Availability
     - MaterialComponents/private/Color
     - MaterialComponents/private/Math
-  - MaterialComponents/Ink (118.1.0):
+  - MaterialComponents/Ink (119.1.0):
     - MaterialComponents/Availability
     - MaterialComponents/private/Color
     - MaterialComponents/private/Math
-  - MaterialComponents/Palettes (118.1.0)
-  - MaterialComponents/private/Application (118.1.0)
-  - MaterialComponents/private/Color (118.1.0):
+  - MaterialComponents/Palettes (119.1.0)
+  - MaterialComponents/private/Application (119.1.0)
+  - MaterialComponents/private/Color (119.1.0):
     - MaterialComponents/Availability
-  - MaterialComponents/private/Math (118.1.0)
-  - MaterialComponents/ProgressView (118.1.0):
+  - MaterialComponents/private/Math (119.1.0)
+  - MaterialComponents/ProgressView (119.1.0):
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
     - MDFInternationalization
-  - MaterialComponents/Ripple (118.1.0):
+  - MaterialComponents/Ripple (119.1.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Availability
     - MaterialComponents/private/Color
     - MaterialComponents/private/Math
-  - MaterialComponents/ShadowElevations (118.1.0)
-  - MaterialComponents/ShadowLayer (118.1.0):
+  - MaterialComponents/ShadowElevations (119.1.0)
+  - MaterialComponents/ShadowLayer (119.1.0):
     - MaterialComponents/ShadowElevations
-  - MaterialComponents/Tabs (118.1.0):
+  - MaterialComponents/Tabs (119.1.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Elevation
     - MaterialComponents/Ink
@@ -62,7 +62,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFInternationalization
-  - MaterialComponents/Typography (118.1.0):
+  - MaterialComponents/Typography (119.1.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/Math
     - MDFTextAccessibility
@@ -85,7 +85,7 @@ PODS:
   - SwiftEntryKit (1.2.1):
     - QuickLayout (= 3.0.0)
   - SwiftLinkPreview (3.0.1)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
   - SwiftyJSON (5.0.0)
   - TGPControls (5.1.0)
   - YoutubePlayer-in-WKWebView (0.3.4)
@@ -160,7 +160,7 @@ CHECKOUT OPTIONS:
     :commit: e76cd225ff60f12f8ec0052e39e5e307a32c0762
     :git: https://github.com/ccrama/MKColorPicker
   reddift:
-    :commit: a1813197efb1952e7045f02621503e6364b63a4b
+    :commit: 5f57e8a1368898e8185ad8313acb7bf4380124b2
     :git: https://github.com/ccrama/reddift
   RLBAlertsPickers:
     :commit: a22003f93a803c2e14b193f636669c21358fb1d7
@@ -181,7 +181,7 @@ SPEC CHECKSUMS:
   DTFoundation: e7781d9fd2f202bfd451fbbf8cab71ce83b46498
   HTMLSpecialCharacters: edc707cc4bcdc92eb3b9551de8cff94c1e6f9a19
   LicensesViewController: 2f7bba13b3cec7516d4990e41df297720fdbaaab
-  MaterialComponents: e4a7c8b5eabe7856ef58f632fb5800a229bda5be
+  MaterialComponents: 04f29e3ec4965c29a48e13a626a0ab4bbd19e289
   MDFInternationalization: 010097556d6b09d2c4ea38e0820ea6d37be6a314
   MDFTextAccessibility: 85c09a1bd9c321f494348e632a25063bcda35a53
   MiniKeychain: 5d424fcd50fb8ab4cc946db2c3415dc391ffffdc
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   SubtleVolume: 101038d203018736bcd1df3ac95bcc0f6b8640ce
   SwiftEntryKit: 1661b766dd22b07679e6ebb326ccfbd81ceb0a20
   SwiftLinkPreview: 7524438c43bf63a5041615713777c3d8f19a9a31
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   SwiftyJSON: f0574c07d8ca1644050db687067209e3033a89a0
   TGPControls: 52c0770bee9c9aee364f1559cc627fc01ea5e8b2
   YoutubePlayer-in-WKWebView: af2f5929fc78882d94bfdfeea999b661b78d9717

--- a/Slide Widgets/SlideWidgets.swift
+++ b/Slide Widgets/SlideWidgets.swift
@@ -377,9 +377,8 @@ struct SubredditLoader {
                 subsString += item
             }
             let subredditUrl = URL(string: "https://reddit.com/r/\(subsString)/hot.json?limit=7&raw_json=1")!
-            print("https://reddit.com/r/\(subsString)/hot.json?limit=7&raw_json=1")
-            var request = URLRequest(url: subredditUrl)
-            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            let request = URLRequest(url: subredditUrl)
+            let task = URLSession.shared.dataTask(with: request) { (data, _, error) in
                 guard error == nil else {
                     completion(.failure(error!))
                     return
@@ -390,7 +389,7 @@ struct SubredditLoader {
             task.resume()
         } else {
             let subredditUrl = URL(string: apiUrl)!
-            let task = URLSession.shared.dataTask(with: subredditUrl) { (data, response, error) in
+            let task = URLSession.shared.dataTask(with: subredditUrl) { (data, _, error) in
                 guard error == nil else {
                     completion(.failure(error!))
                     return
@@ -423,8 +422,6 @@ struct SubredditLoader {
                     }
                 }
             }
-        } catch {
-            
         }
         
         return SubredditPosts(date: Date(), subreddit: subreddit, posts: posts)

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 		BE2F3F5A1EF8DD3D003C1B28 /* SettingsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */; };
 		BE2F3F5D1EF96877003C1B28 /* SettingsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */; };
 		BE3144FF25663674004A908C /* AsyncTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3144FE25663674004A908C /* AsyncTextAttachment.swift */; };
-		BE314509256738FF004A908C /* BadgeLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE314508256738FF004A908C /* BadgeLayoutManager.swift */; };
+		BE314509256738FF004A908C /* TitleUITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE314508256738FF004A908C /* TitleUITextView.swift */; };
 		BE31454625674E03004A908C /* Proton in Frameworks */ = {isa = PBXBuildFile; productRef = BE31454525674E03004A908C /* Proton */; };
 		BE35216A1E3D22B000C30B8D /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */; };
 		BE35216B1E3D22B000C30B8D /* Roboto-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */; };
@@ -683,7 +683,7 @@
 		BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsData.swift; sourceTree = "<group>"; };
 		BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContent.swift; sourceTree = "<group>"; };
 		BE3144FE25663674004A908C /* AsyncTextAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTextAttachment.swift; sourceTree = "<group>"; };
-		BE314508256738FF004A908C /* BadgeLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLayoutManager.swift; sourceTree = "<group>"; };
+		BE314508256738FF004A908C /* TitleUITextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleUITextView.swift; sourceTree = "<group>"; };
 		BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Light.ttf"; sourceTree = "<group>"; };
 		BE3521671E3D22B000C30B8D /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
@@ -1552,7 +1552,7 @@
 				BE36886120E5709300987320 /* FullLinkCellView.swift */,
 				BE1CD01220F43E51007746B6 /* TextDisplayStackView.swift */,
 				BE854972239310E300D51DDC /* GalleryLinkCellView.swift */,
-				BE314508256738FF004A908C /* BadgeLayoutManager.swift */,
+				BE314508256738FF004A908C /* TitleUITextView.swift */,
 			);
 			name = LinkCellViews;
 			sourceTree = "<group>";
@@ -2399,7 +2399,7 @@
 				BE1CD01520F51C37007746B6 /* RemovalReasons.swift in Sources */,
 				BE9742381F0409BA00BF48E0 /* SettingsComments.swift in Sources */,
 				BE25CADC24C4E3DA00736CA5 /* MainViewController.swift in Sources */,
-				BE314509256738FF004A908C /* BadgeLayoutManager.swift in Sources */,
+				BE314509256738FF004A908C /* TitleUITextView.swift in Sources */,
 				BE2F3F581EF886D9003C1B28 /* Reachability.swift in Sources */,
 				BE9BFF1D25182D8700C9F7EC /* OnboardingPageViewController.swift in Sources */,
 				098B5A4B20EFC6C000FE201B /* UILabel+Extensions.swift in Sources */,

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		BE2F3F581EF886D9003C1B28 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F571EF886D9003C1B28 /* Reachability.swift */; };
 		BE2F3F5A1EF8DD3D003C1B28 /* SettingsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */; };
 		BE2F3F5D1EF96877003C1B28 /* SettingsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */; };
+		BE3144FF25663674004A908C /* AsyncTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3144FE25663674004A908C /* AsyncTextAttachment.swift */; };
 		BE35216A1E3D22B000C30B8D /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */; };
 		BE35216B1E3D22B000C30B8D /* Roboto-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */; };
 		BE35216C1E3D22B000C30B8D /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521671E3D22B000C30B8D /* Roboto-Medium.ttf */; };
@@ -679,6 +680,7 @@
 		BE2F3F571EF886D9003C1B28 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsData.swift; sourceTree = "<group>"; };
 		BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContent.swift; sourceTree = "<group>"; };
+		BE3144FE25663674004A908C /* AsyncTextAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTextAttachment.swift; sourceTree = "<group>"; };
 		BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Light.ttf"; sourceTree = "<group>"; };
 		BE3521671E3D22B000C30B8D /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
@@ -1505,6 +1507,7 @@
 				BEBF38092563716B00C91668 /* ModlogContributionLoader.swift */,
 				BEBF3813256376AC00C91668 /* ModerationOverviewViewController.swift */,
 				BEAE6A4A2564CCC100EF0806 /* ModLogCellView.swift */,
+				BE3144FE25663674004A908C /* AsyncTextAttachment.swift */,
 			);
 			path = "Slide for Reddit";
 			sourceTree = "<group>";
@@ -2328,6 +2331,7 @@
 				BE2F3F4C1EF62021003C1B28 /* SettingsLayout.swift in Sources */,
 				0965260B20E2987800EA53BE /* UISearchBar+Extensions.swift in Sources */,
 				BEB81A6821445FE4007E326B /* FriendCellView.swift in Sources */,
+				BE3144FF25663674004A908C /* AsyncTextAttachment.swift in Sources */,
 				BEBE0C6F222199DA0044FF55 /* IAPHandlerTip.swift in Sources */,
 				BE11351C2159390700502C5B /* WatchSessionManager.swift in Sources */,
 				BE7439ED1E201C22008BB63B /* SubredditCellView.swift in Sources */,

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		BE9BFF1D25182D8700C9F7EC /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9BFF1925182D8600C9F7EC /* OnboardingPageViewController.swift */; };
 		BE9BFF2725182EDB00C9F7EC /* v6howtonavigate.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = BE9BFF2625182ED500C9F7EC /* v6howtonavigate.mp4 */; };
 		BEAD1F75251424CB0096A216 /* SubredditThemeEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAD1F74251424CB0096A216 /* SubredditThemeEditViewController.swift */; };
+		BEAE6A4B2564CCC100EF0806 /* ModLogCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAE6A4A2564CCC100EF0806 /* ModLogCellView.swift */; };
 		BEB2B2351E35D25100BF761C /* InboxContributionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB2B2341E35D25100BF761C /* InboxContributionLoader.swift */; };
 		BEB2B2371E35D48000BF761C /* InboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB2B2361E35D48000BF761C /* InboxViewController.swift */; };
 		BEB2B2391E35D64F00BF761C /* MessageCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB2B2381E35D64F00BF761C /* MessageCellView.swift */; };
@@ -319,6 +320,8 @@
 		BEB81A6821445FE4007E326B /* FriendCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB81A6721445FE4007E326B /* FriendCellView.swift */; };
 		BEBE0C6F222199DA0044FF55 /* IAPHandlerTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBE0C6E222199DA0044FF55 /* IAPHandlerTip.swift */; };
 		BEBE0C71222330010044FF55 /* SettingsPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBE0C70222330010044FF55 /* SettingsPostMenu.swift */; };
+		BEBF380A2563716B00C91668 /* ModlogContributionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF38092563716B00C91668 /* ModlogContributionLoader.swift */; };
+		BEBF3814256376AC00C91668 /* ModerationOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF3813256376AC00C91668 /* ModerationOverviewViewController.swift */; };
 		BEBF45C81E230CC900764BB8 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF45C71E230CC900764BB8 /* History.swift */; };
 		BEBF45DB1E23383D00764BB8 /* seen.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEBF45DA1E23383D00764BB8 /* seen.plist */; };
 		BEBF45DD1E23384500764BB8 /* comments.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEBF45DC1E23384500764BB8 /* comments.plist */; };
@@ -789,6 +792,7 @@
 		BE9BFF1925182D8600C9F7EC /* OnboardingPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OnboardingPageViewController.swift; path = "Slide for Reddit/Onboarding2/OnboardingPageViewController.swift"; sourceTree = SOURCE_ROOT; };
 		BE9BFF2625182ED500C9F7EC /* v6howtonavigate.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = v6howtonavigate.mp4; sourceTree = "<group>"; };
 		BEAD1F74251424CB0096A216 /* SubredditThemeEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditThemeEditViewController.swift; sourceTree = "<group>"; };
+		BEAE6A4A2564CCC100EF0806 /* ModLogCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModLogCellView.swift; sourceTree = "<group>"; };
 		BEB2B2341E35D25100BF761C /* InboxContributionLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxContributionLoader.swift; sourceTree = "<group>"; };
 		BEB2B2361E35D48000BF761C /* InboxViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxViewController.swift; sourceTree = "<group>"; };
 		BEB2B2381E35D64F00BF761C /* MessageCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCellView.swift; sourceTree = "<group>"; };
@@ -799,6 +803,8 @@
 		BEB81A6721445FE4007E326B /* FriendCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCellView.swift; sourceTree = "<group>"; };
 		BEBE0C6E222199DA0044FF55 /* IAPHandlerTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPHandlerTip.swift; sourceTree = "<group>"; };
 		BEBE0C70222330010044FF55 /* SettingsPostMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPostMenu.swift; sourceTree = "<group>"; };
+		BEBF38092563716B00C91668 /* ModlogContributionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModlogContributionLoader.swift; sourceTree = "<group>"; };
+		BEBF3813256376AC00C91668 /* ModerationOverviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationOverviewViewController.swift; sourceTree = "<group>"; };
 		BEBF45C71E230CC900764BB8 /* History.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		BEBF45DA1E23383D00764BB8 /* seen.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = seen.plist; sourceTree = "<group>"; };
 		BEBF45DC1E23384500764BB8 /* comments.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = comments.plist; sourceTree = "<group>"; };
@@ -1496,6 +1502,9 @@
 				BE9BFDC724F7198200D74167 /* WrappingHeaderFlowLayout.swift */,
 				BEAD1F74251424CB0096A216 /* SubredditThemeEditViewController.swift */,
 				BE836477254A3A8B00677F8A /* TrendingViewController.swift */,
+				BEBF38092563716B00C91668 /* ModlogContributionLoader.swift */,
+				BEBF3813256376AC00C91668 /* ModerationOverviewViewController.swift */,
+				BEAE6A4A2564CCC100EF0806 /* ModLogCellView.swift */,
 			);
 			path = "Slide for Reddit";
 			sourceTree = "<group>";
@@ -2314,6 +2323,7 @@
 				BE3E5C1D1E177B2C00749C0C /* CommentViewController.swift in Sources */,
 				BE1DA5C6220803BB001C7DB4 /* UIAlert+Extensions.swift in Sources */,
 				BE8AE94721F922F400E1C0D1 /* ColorPickerViewController.swift in Sources */,
+				BEBF3814256376AC00C91668 /* ModerationOverviewViewController.swift in Sources */,
 				BE7439EB1E201BB0008BB63B /* SubredditToolbarSearchViewController.swift in Sources */,
 				BE2F3F4C1EF62021003C1B28 /* SettingsLayout.swift in Sources */,
 				0965260B20E2987800EA53BE /* UISearchBar+Extensions.swift in Sources */,
@@ -2326,6 +2336,7 @@
 				BE7A2D3E22AD99600005F74F /* DragDownAlertMenu.swift in Sources */,
 				0965260720E28FEE00EA53BE /* UIStackView+Extensions.swift in Sources */,
 				0984BE4E2114C4040091C2E1 /* PostContentPresentationManager.swift in Sources */,
+				BEAE6A4B2564CCC100EF0806 /* ModLogCellView.swift in Sources */,
 				BE1DA3961E26AD5700EC0A04 /* SearchViewController.swift in Sources */,
 				09F411CF20F3EEB900D23A42 /* ImageMediaViewController.swift in Sources */,
 				BEC4A1A8232EA30B00EE5114 /* ProfileInfoPresentationManager.swift in Sources */,
@@ -2368,6 +2379,7 @@
 				BEE5BF841E14836E00E3C9AE /* MediaVCDelegate.swift in Sources */,
 				BE2B89FB1E253D610053D493 /* ReplyViewController.swift in Sources */,
 				BED3B31924CE278B00B9A664 /* SettingsShortcutMenu.swift in Sources */,
+				BEBF380A2563716B00C91668 /* ModlogContributionLoader.swift in Sources */,
 				BEC4A1B4232F3F1800EE5114 /* CollectionsContributionLoader.swift in Sources */,
 				096A7D172215EC920067106C /* SettingsAudio.swift in Sources */,
 				09526EFA214C39F0005A3F6B /* CGPoint+Extensions.swift in Sources */,

--- a/Slide for Reddit.xcodeproj/project.pbxproj
+++ b/Slide for Reddit.xcodeproj/project.pbxproj
@@ -206,6 +206,8 @@
 		BE2F3F5A1EF8DD3D003C1B28 /* SettingsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */; };
 		BE2F3F5D1EF96877003C1B28 /* SettingsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */; };
 		BE3144FF25663674004A908C /* AsyncTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3144FE25663674004A908C /* AsyncTextAttachment.swift */; };
+		BE314509256738FF004A908C /* BadgeLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE314508256738FF004A908C /* BadgeLayoutManager.swift */; };
+		BE31454625674E03004A908C /* Proton in Frameworks */ = {isa = PBXBuildFile; productRef = BE31454525674E03004A908C /* Proton */; };
 		BE35216A1E3D22B000C30B8D /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */; };
 		BE35216B1E3D22B000C30B8D /* Roboto-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */; };
 		BE35216C1E3D22B000C30B8D /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BE3521671E3D22B000C30B8D /* Roboto-Medium.ttf */; };
@@ -681,6 +683,7 @@
 		BE2F3F591EF8DD3D003C1B28 /* SettingsData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsData.swift; sourceTree = "<group>"; };
 		BE2F3F5C1EF96877003C1B28 /* SettingsContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContent.swift; sourceTree = "<group>"; };
 		BE3144FE25663674004A908C /* AsyncTextAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTextAttachment.swift; sourceTree = "<group>"; };
+		BE314508256738FF004A908C /* BadgeLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLayoutManager.swift; sourceTree = "<group>"; };
 		BE3521651E3D22B000C30B8D /* Roboto-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		BE3521661E3D22B000C30B8D /* Roboto-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Light.ttf"; sourceTree = "<group>"; };
 		BE3521671E3D22B000C30B8D /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
@@ -905,6 +908,7 @@
 				BE51BE6520C7386A00DFFD8B /* StoreKit.framework in Frameworks */,
 				B4F3354C25127BAB0032BB64 /* Anchorage in Frameworks */,
 				B4F3348B2512770F0032BB64 /* Embassy in Frameworks */,
+				BE31454625674E03004A908C /* Proton in Frameworks */,
 				BE2E9F0823492B4300FE07B4 /* CloudKit.framework in Frameworks */,
 				BE7BFB481F1997BA009CA2E1 /* MapKit.framework in Frameworks */,
 				B4F3349F251277B80032BB64 /* Starscream in Frameworks */,
@@ -1548,6 +1552,7 @@
 				BE36886120E5709300987320 /* FullLinkCellView.swift */,
 				BE1CD01220F43E51007746B6 /* TextDisplayStackView.swift */,
 				BE854972239310E300D51DDC /* GalleryLinkCellView.swift */,
+				BE314508256738FF004A908C /* BadgeLayoutManager.swift */,
 			);
 			name = LinkCellViews;
 			sourceTree = "<group>";
@@ -1695,6 +1700,7 @@
 				B4F3349E251277B80032BB64 /* Starscream */,
 				B4F3354B25127BAB0032BB64 /* Anchorage */,
 				B4F3355525127BD20032BB64 /* Then */,
+				BE31454525674E03004A908C /* Proton */,
 			);
 			productName = "Slide for Reddit";
 			productReference = BE8FCA041E0C46090063B8EF /* Slide for Reddit.app */;
@@ -1865,6 +1871,7 @@
 				B4F3349D251277B80032BB64 /* XCRemoteSwiftPackageReference "Starscream" */,
 				B4F3354A25127BAB0032BB64 /* XCRemoteSwiftPackageReference "Anchorage" */,
 				B4F3355425127BD20032BB64 /* XCRemoteSwiftPackageReference "Then" */,
+				BE31454425674E03004A908C /* XCRemoteSwiftPackageReference "proton" */,
 			);
 			productRefGroup = BE8FCA051E0C46090063B8EF /* Products */;
 			projectDirPath = "";
@@ -2392,6 +2399,7 @@
 				BE1CD01520F51C37007746B6 /* RemovalReasons.swift in Sources */,
 				BE9742381F0409BA00BF48E0 /* SettingsComments.swift in Sources */,
 				BE25CADC24C4E3DA00736CA5 /* MainViewController.swift in Sources */,
+				BE314509256738FF004A908C /* BadgeLayoutManager.swift in Sources */,
 				BE2F3F581EF886D9003C1B28 /* Reachability.swift in Sources */,
 				BE9BFF1D25182D8700C9F7EC /* OnboardingPageViewController.swift in Sources */,
 				098B5A4B20EFC6C000FE201B /* UILabel+Extensions.swift in Sources */,
@@ -3424,6 +3432,14 @@
 				minimumVersion = 2.7.0;
 			};
 		};
+		BE31454425674E03004A908C /* XCRemoteSwiftPackageReference "proton" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rajdeep/proton";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3471,6 +3487,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B4F3355425127BD20032BB64 /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
+		};
+		BE31454525674E03004A908C /* Proton */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BE31454425674E03004A908C /* XCRemoteSwiftPackageReference "proton" */;
+			productName = Proton;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
@@ -65,8 +65,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Slide for Apple Watch Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Slide for Reddit">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -74,7 +76,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,8 +84,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Slide for Reddit">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -91,7 +95,16 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BE20851021588F3900D8F33C"
+            BuildableName = "Slide for Apple Watch.app"
+            BlueprintName = "Slide for Apple Watch"
+            ReferencedContainer = "container:Slide for Reddit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
+++ b/Slide for Reddit.xcodeproj/xcshareddata/xcschemes/Slide for Apple Watch.xcscheme
@@ -65,10 +65,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Slide for Apple Watch Extension/PushNotificationPayload.apns">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Slide for Reddit">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -76,7 +74,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -84,10 +82,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Slide for Reddit">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BE20851021588F3900D8F33C"
@@ -95,16 +91,7 @@
             BlueprintName = "Slide for Apple Watch"
             ReferencedContainer = "container:Slide for Reddit.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BE20851021588F3900D8F33C"
-            BuildableName = "Slide for Apple Watch.app"
-            BlueprintName = "Slide for Apple Watch"
-            ReferencedContainer = "container:Slide for Reddit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>43</integer>
+			<integer>45</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>42</integer>
+			<integer>46</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>42</integer>
+			<integer>43</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>43</integer>
+			<integer>42</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>45</integer>
+			<integer>43</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>46</integer>
+			<integer>42</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>52</integer>
+			<integer>43</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>51</integer>
+			<integer>42</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>43</integer>
+			<integer>42</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>42</integer>
+			<integer>43</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Slide for Reddit.xcodeproj/xcuserdata/carloscrane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -27,7 +27,7 @@
 		<key>Slide Widgets.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>42</integer>
+			<integer>52</integer>
 		</dict>
 		<key>Slide for Apple Watch (Notification).xcscheme</key>
 		<dict>
@@ -52,7 +52,7 @@
 		<key>WidgetConfigIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>43</integer>
+			<integer>51</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Slide for Reddit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "Proton",
+        "repositoryURL": "https://github.com/rajdeep/proton",
+        "state": {
+          "branch": null,
+          "revision": "e9257e11ff2a708f6b6ea98a9d593ab3bef7ea1b",
+          "version": "0.5.0"
+        }
+      },
+      {
         "package": "Realm",
         "repositoryURL": "https://github.com/realm/realm-cocoa.git",
         "state": {

--- a/Slide for Reddit/AccountController.swift
+++ b/Slide for Reddit/AccountController.swift
@@ -225,7 +225,9 @@ class AccountController {
                     } else {
                         for sub in toReturn {
                             Subscriptions.subIcons[sub.displayName.lowercased()] = sub.iconImg == "" ? sub.communityIcon : sub.iconImg
-                            Subscriptions.subColors[sub.displayName.lowercased()] = sub.keyColor
+                            if sub.keyColor.hexString().lowercased() != "#ffffff" && sub.keyColor.hexString() != "#000000" {
+                                Subscriptions.subColors[sub.displayName.lowercased()] = sub.keyColor
+                            }
                         }
 
                         completion(toReturn)

--- a/Slide for Reddit/AppDelegate.swift
+++ b/Slide for Reddit/AppDelegate.swift
@@ -782,7 +782,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 })
             }
         }
-
     }
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/Slide for Reddit/AppDelegate.swift
+++ b/Slide for Reddit/AppDelegate.swift
@@ -735,14 +735,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             toReturn.append(sub.displayName)
                             Subscriptions.subIcons[sub.displayName.lowercased()] = sub.iconImg == "" ? sub.communityIcon : sub.iconImg
                             Subscriptions.subColors[sub.displayName.lowercased()] = sub.keyColor
-
-                            /* Not needed, we pull from the key color now
-                            if sub.keyColor.hexString() != "#FFFFFF" {
-                                let color = ColorUtil.getClosestColor(hex: sub.keyColor.hexString())
-                                if defaults.object(forKey: "color" + sub.displayName) == nil {
-                                    defaults.setColor(color: color, forKey: "color+" + sub.displayName)
-                                }
-                            }*/
                         }
                     }
                     if subredditController != nil {
@@ -764,21 +756,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     Subscriptions.getSubscriptionsFully(session: session!, completion: { (subs, multis) in
                         for sub in subs {
                             toReturn.append(sub.displayName)
-                            /*if sub.keyColor.hexString() != "#FFFFFF" {
-                                let color = ColorUtil.getClosestColor(hex: sub.keyColor.hexString())
-                                if defaults.object(forKey: "color" + sub.displayName) == nil {
-                                    defaults.setColor(color: color, forKey: "color+" + sub.displayName)
-                                }
-                            }*/
                         }
                         for m in multis {
-                            toReturn.append("/m/" + m.displayName)
-                            if !m.keyColor.isEmpty {
-                                let color = (UIColor.init(hexString: m.keyColor))
-                                if defaults.object(forKey: "color" + m.displayName) == nil {
-                                    defaults.setColor(color: color, forKey: "color+" + m.displayName)
-                                }
-                            }
+                            toReturn.append("/m/" + m.displayName.replacingOccurrences(of: " ", with: "_"))
                         }
                         
                         toReturn = toReturn.sorted {

--- a/Slide for Reddit/AppDelegate.swift
+++ b/Slide for Reddit/AppDelegate.swift
@@ -382,7 +382,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         #if DEBUG
-        SettingValues.isPro = true
+        SettingValues.isPro = false
         UserDefaults.standard.set(true, forKey: SettingValues.pref_pro)
         UserDefaults.standard.synchronize()
         UIApplication.shared.isIdleTimerDisabled = true

--- a/Slide for Reddit/AsyncTextAttachment.swift
+++ b/Slide for Reddit/AsyncTextAttachment.swift
@@ -1,0 +1,175 @@
+//
+//  Slide for Reddit
+//
+//  Modified by Carlos Crane on 11/18/20.
+//
+
+//
+//  AsyncTextAttachment.swift
+//  Attachments
+//
+//  Created by Oliver Drobnik on 01/09/2016.
+//  Copyright © 2016 Cocoanetics. All rights reserved.
+//
+import UIKit
+import MobileCoreServices
+import SDWebImage
+
+
+@objc public protocol AsyncTextAttachmentDelegate {
+    /// Called when the image has been loaded
+    func textAttachmentDidLoadImage(textAttachment: AsyncTextAttachment, displaySizeChanged: Bool)
+}
+
+/// An image text attachment that gets loaded from a remote URL
+public class AsyncTextAttachment: NSTextAttachment {
+    /// Remote URL for the image
+    public var imageURL: URL?
+    
+    /// Whether to round the image corners
+    public var rounded: Bool
+    
+    /// Color for background of image
+    public var backgroundColor: UIColor?
+    
+    /// To specify an absolute display size.
+    public var displaySize: CGSize?
+    
+    /// if determining the display size automatically this can be used to specify a maximum width. If it is not set then the text container's width will be used
+    public var maximumDisplayWidth: CGFloat?
+    
+    /// A delegate to be informed of the finished download
+    public weak var delegate: AsyncTextAttachmentDelegate?
+    
+    /// Remember the text container from delegate message, the current one gets updated after the download
+    weak var textContainer: NSTextContainer?
+    
+    /// The size of the downloaded image. Used if we need to determine display size
+    private var originalImageSize: CGSize?
+    
+    /// Designated initializer
+    public init(imageURL: URL? = nil, delegate: AsyncTextAttachmentDelegate? = nil, rounded: Bool, backgroundColor: UIColor?) {
+        self.imageURL = imageURL
+        self.delegate = delegate
+        self.rounded = rounded
+        self.backgroundColor = backgroundColor
+        
+        super.init(data: nil, ofType: nil)
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override public var image: UIImage? {
+        didSet {
+            originalImageSize = image?.size
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func startAsyncImageDownload() {
+        guard let imageURL = imageURL, contents == nil else {
+            return
+        }
+        
+        SDWebImageDownloader.shared.downloadImage(with: imageURL) { (image, data, _, _) in
+            self.contents = data
+            
+            let ext = imageURL.pathExtension as CFString
+            if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, ext, nil) {
+                self.fileType = uti.takeRetainedValue() as String
+            }
+            if let image = image?.circleCorners(finalSize: self.bounds.size) { //2 was causing weird clipping
+                let imageSize = image.size
+                               
+                self.contents = image.pngData()
+                self.originalImageSize = imageSize
+            }
+            
+            DispatchQueue.main.async {
+                self.textContainer?.layoutManager?.setNeedsDisplay(forAttachment: self)
+
+                self.delegate?.textAttachmentDidLoadImage(textAttachment: self, displaySizeChanged: false)
+            }
+            
+        }
+    }
+    
+    public override func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
+        if let image = image { return image }
+        
+        guard let contents = contents, let image = UIImage(data: contents) else {
+            // remember reference so that we can update it later
+            self.textContainer = textContainer
+            
+            startAsyncImageDownload()
+            
+            return nil
+        }
+        
+        return image
+    }
+    
+    public override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        return self.bounds
+    }
+}
+
+extension NSLayoutManager {
+    /// Determine the character ranges for an attachment
+    private func rangesForAttachment(attachment: NSTextAttachment) -> [NSRange]? {
+        guard let attributedString = self.textStorage else {
+            return nil
+        }
+        
+        // find character range for this attachment
+        let range = NSRange(location: 0, length: attributedString.length)
+        
+        var refreshRanges = [NSRange]()
+        
+        attributedString.enumerateAttribute(NSAttributedString.Key.attachment, in: range, options: []) { (value, effectiveRange, nil) in
+            
+            guard let foundAttachment = value as? NSTextAttachment, foundAttachment == attachment else {
+                return
+            }
+            
+            // add this range to the refresh ranges
+            refreshRanges.append(effectiveRange)
+        }
+        
+        if refreshRanges.count == 0 {
+            return nil
+        }
+        
+        return refreshRanges
+    }
+    
+    /// Trigger a relayout for an attachment
+    public func setNeedsLayout(forAttachment attachment: NSTextAttachment) {
+        guard let ranges = rangesForAttachment(attachment: attachment) else {
+            return
+        }
+
+        // invalidate the display for the corresponding ranges
+        for range in ranges.reversed() {
+            self.invalidateLayout(forCharacterRange: range, actualCharacterRange: nil)
+
+            // also need to trigger re-display or already visible images might not get updated
+            self.invalidateDisplay(forCharacterRange: range)
+        }
+    }
+    
+    /// Trigger a re-display for an attachment
+    public func setNeedsDisplay(forAttachment attachment: NSTextAttachment) {
+        guard let ranges = rangesForAttachment(attachment: attachment) else {
+            return
+        }
+
+        // invalidate the display for the corresponding ranges
+        for range in ranges.reversed() {
+            self.invalidateDisplay(forCharacterRange: range)
+        }
+    }
+}

--- a/Slide for Reddit/AsyncTextAttachment.swift
+++ b/Slide for Reddit/AsyncTextAttachment.swift
@@ -74,7 +74,7 @@ public class AsyncTextAttachment: NSTextAttachment {
             return
         }
         
-        SDWebImageDownloader.shared.downloadImage(with: imageURL) { (image, data, _, _) in
+        SDWebImageDownloader.shared.downloadImage(with: imageURL, options: [.decodeFirstFrameOnly], progress: nil) { (image, data, _, _) in
             self.contents = data
             
             let ext = imageURL.pathExtension as CFString

--- a/Slide for Reddit/AutoCache.swift
+++ b/Slide for Reddit/AutoCache.swift
@@ -301,7 +301,7 @@ public class AutoCache: NSObject {
         button.heightAnchor /==/ 25
         button.widthAnchor /==/ 25
         button.centerYAnchor /==/ popup.centerYAnchor
-        button.addTapGestureRecognizer {
+        button.addTapGestureRecognizer { (_) in
             AutoCache.cancelAutocache(completed: -1)
         }
         button.isUserInteractionEnabled = true

--- a/Slide for Reddit/AutoplayBannerLinkCellView.swift
+++ b/Slide for Reddit/AutoplayBannerLinkCellView.swift
@@ -37,8 +37,7 @@ final class AutoplayBannerLinkCellView: LinkCellView {
                     title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
                 }
                 
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2  ~ .required
-                awardContainerView.bottomAnchor /<=/ bannerImage.topAnchor - ceight / 2  ~ .required
+                title.bottomAnchor /==/ bannerImage.topAnchor - ceight ~ .required
 
                 bannerImage.horizontalAnchors /==/ innerView.horizontalAnchors + bannerPadding
                 
@@ -63,11 +62,9 @@ final class AutoplayBannerLinkCellView: LinkCellView {
                 }
                 
                 if !SettingValues.actionBarMode.isFull() {
-                    title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                    awardContainerView.bottomAnchor /<=/ innerView.bottomAnchor - ceight / 2 ~ .required
+                    title.bottomAnchor /==/ innerView.bottomAnchor - ceight ~ .required
                 } else {
-                    title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                    awardContainerView.bottomAnchor /==/ box.topAnchor - ceight / 2 ~ .required
+                    title.bottomAnchor /==/ box.topAnchor - ceight / 2 ~ .required
                 }
                 
                 bannerImage.topAnchor /==/ innerView.topAnchor + bannerPadding  ~ .required

--- a/Slide for Reddit/BadgeLayoutManager.swift
+++ b/Slide for Reddit/BadgeLayoutManager.swift
@@ -1,0 +1,244 @@
+//
+//  BadgeLayoutManager.swift
+//  Slide for Reddit
+//
+//  Created by Rajdeep Kwatra on 11/5/20.
+//  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
+//
+//  Code based off https://github.com/rajdeep/proton/blob/d1a3c855fdabd487ed01c1d6dadff559a5843f28/Proton/Sources/Core/LayoutManager.swift
+//
+
+import UIKit
+import Foundation
+
+class BadgeLayoutManager: NSLayoutManager {
+    override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
+        super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+        guard let textStorage = textStorage,
+            let currentCGContext = UIGraphicsGetCurrentContext() else {
+                return
+        }
+
+        let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
+        textStorage.enumerateAttribute(.badgeColor, in: characterRange) { attr, bgStyleRange, _ in
+            var rects = [CGRect]()
+            if let backgroundStyle = attr as? UIColor {
+                let bgStyleGlyphRange = self.glyphRange(forCharacterRange: bgStyleRange, actualCharacterRange: nil)
+                enumerateLineFragments(forGlyphRange: bgStyleGlyphRange) { _, usedRect, textContainer, lineRange, _ in
+                    let rangeIntersection = NSIntersectionRange(bgStyleGlyphRange, lineRange)
+                    var rect = self.boundingRect(forGlyphRange: rangeIntersection, in: textContainer)
+                    // Glyphs can take space outside of the line fragment, and we cannot draw outside of it.
+                    // So it is best to restrict the height just to the line fragment.
+                    rect.origin.y = usedRect.origin.y
+                    rect.size.height = usedRect.height
+                    let insetTop = CGFloat.zero
+                    rects.append(rect.offsetBy(dx: 0, dy: insetTop))
+                }
+                drawBackground(backgroundStyle: backgroundStyle, rects: rects, currentCGContext: currentCGContext)
+            }
+        }
+    }
+
+    private func drawBackground(backgroundStyle: UIColor, rects: [CGRect], currentCGContext: CGContext) {
+        currentCGContext.saveGState()
+
+        let rectCount = rects.count
+        let rectArray = rects
+        let cornerRadius = CGFloat(3)
+        let color = backgroundStyle
+
+        for i in 0..<rectCount {
+            var previousRect = CGRect.zero
+            var nextRect = CGRect.zero
+
+            let currentRect = rectArray[i]
+
+            if i > 0 {
+                previousRect = rectArray[i - 1]
+            }
+
+            if i < rectCount - 1 {
+                nextRect = rectArray[i + 1]
+            }
+
+            let corners = calculateCornersForBackground(previousRect: previousRect, currentRect: currentRect, nextRect: nextRect, cornerRadius: cornerRadius)
+
+            let rectanglePath = UIBezierPath(roundedRect: currentRect, byRoundingCorners: corners, cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
+            color.set()
+
+            currentCGContext.setAllowsAntialiasing(true)
+            currentCGContext.setShouldAntialias(true)
+
+            currentCGContext.setFillColor(color.cgColor)
+            currentCGContext.addPath(rectanglePath.cgPath)
+            currentCGContext.drawPath(using: .fill)
+
+            let lineWidth = CGFloat.zero //Stroke
+            let overlappingLine = UIBezierPath()
+
+            let leftVerticalJoiningLine = UIBezierPath()
+            let rightVerticalJoiningLine = UIBezierPath()
+
+            let leftVerticalJoiningLineShadow = UIBezierPath()
+            let rightVerticalJoiningLineShadow = UIBezierPath()
+
+            if previousRect != .zero, (currentRect.maxX - previousRect.minX) > cornerRadius {
+                let yDiff = currentRect.minY - previousRect.maxY
+                overlappingLine.move(to: CGPoint(x: max(previousRect.minX, currentRect.minX) + lineWidth / 2, y: previousRect.maxY + yDiff/2))
+                overlappingLine.addLine(to: CGPoint(x: min(previousRect.maxX, currentRect.maxX) - lineWidth / 2, y: previousRect.maxY + yDiff/2))
+
+                let leftX = max(previousRect.minX, currentRect.minX)
+                let rightX = min(previousRect.maxX, currentRect.maxX)
+
+                leftVerticalJoiningLine.move(to: CGPoint(x: leftX, y: previousRect.maxY))
+                leftVerticalJoiningLine.addLine(to: CGPoint(x: leftX, y: currentRect.minY))
+
+                rightVerticalJoiningLine.move(to: CGPoint(x: rightX, y: previousRect.maxY))
+                rightVerticalJoiningLine.addLine(to: CGPoint(x: rightX, y: currentRect.minY))
+
+                let leftShadowX = max(previousRect.minX, currentRect.minX) + lineWidth
+                let rightShadowX = min(previousRect.maxX, currentRect.maxX) - lineWidth
+
+                leftVerticalJoiningLineShadow.move(to: CGPoint(x: leftShadowX, y: previousRect.maxY))
+                leftVerticalJoiningLineShadow.addLine(to: CGPoint(x: leftShadowX, y: currentRect.minY))
+
+                rightVerticalJoiningLineShadow.move(to: CGPoint(x: rightShadowX, y: previousRect.maxY))
+                rightVerticalJoiningLineShadow.addLine(to: CGPoint(x: rightShadowX, y: currentRect.minY))
+            }
+
+            currentCGContext.setShadow(offset: .zero, blur:0, color: UIColor.clear.cgColor)
+
+            // always draw over the overlapping bounds of previous and next rect to hide shadow/borders
+            currentCGContext.setStrokeColor(color.cgColor)
+            currentCGContext.addPath(overlappingLine.cgPath)
+            // account for the spread of shadow
+            let blur = (1) * 2
+            let offsetHeight = CGFloat(1)
+            currentCGContext.setLineWidth(lineWidth + (currentRect.minY - previousRect.maxY) + CGFloat(blur) + offsetHeight + CGFloat(1))
+            currentCGContext.drawPath(using: .stroke)
+        }
+        currentCGContext.restoreGState()
+    }
+
+    private func calculateCornersForBackground(previousRect: CGRect, currentRect: CGRect, nextRect: CGRect, cornerRadius: CGFloat) -> UIRectCorner {
+        var corners = UIRectCorner()
+
+        if previousRect.minX > currentRect.minX {
+            corners.formUnion(.topLeft)
+        }
+
+        if previousRect.maxX < currentRect.maxX {
+            corners.formUnion(.topRight)
+        }
+
+        if currentRect.maxX > nextRect.maxX {
+            corners.formUnion(.bottomRight)
+        }
+
+        if currentRect.minX < nextRect.minX {
+            corners.formUnion(.bottomLeft)
+        }
+
+        if nextRect == .zero || nextRect.maxX <= currentRect.minX + cornerRadius {
+            corners.formUnion(.bottomLeft)
+            corners.formUnion(.bottomRight)
+        }
+
+        if previousRect == .zero || (currentRect.maxX <= previousRect.minX + cornerRadius) {
+            corners.formUnion(.topLeft)
+            corners.formUnion(.topRight)
+        }
+
+        return corners
+    }
+
+    private func getCornersForBackground(textStorage: NSTextStorage, for charRange: NSRange) -> UIRectCorner {
+        let isFirst = (charRange.location == 0)
+            || (textStorage.attribute(.badgeColor, at: charRange.location - 1, effectiveRange: nil) == nil)
+
+        let isLast = (charRange.endLocation == textStorage.length) ||
+            (textStorage.attribute(.badgeColor, at: charRange.location + charRange.length, effectiveRange: nil) == nil)
+
+        var corners = UIRectCorner()
+        if isFirst {
+            corners.formUnion(.topLeft)
+            corners.formUnion(.bottomLeft)
+        }
+
+        if isLast {
+            corners.formUnion(.topRight)
+            corners.formUnion(.bottomRight)
+        }
+
+        return corners
+    }
+}
+
+extension NSAttributedString.Key {
+    static let badgeColor: NSAttributedString.Key = .init("badgeColor")
+}
+
+//
+//  NSRangeExtensions.swift
+//  Proton
+//
+//  Created by Rajdeep Kwatra on 3/1/20.
+//  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Foundation
+import UIKit
+
+public extension NSRange {
+
+    /// Range with 0 location and length
+    static var zero: NSRange {
+        return NSRange(location: 0, length: 0)
+    }
+
+    var firstCharacterRange: NSRange {
+        return NSRange(location: location, length: 1)
+    }
+
+    var lastCharacterRange: NSRange {
+        return NSRange(location: location + length, length: 1)
+    }
+
+    var nextPosition: NSRange {
+        return NSRange(location: location + 1, length: 0)
+    }
+
+    var endLocation: Int {
+        return location + length
+    }
+
+    /// Converts the range to `UITextRange` in given `UITextInput`. Returns nil if the range is invalid in the `UITextInput`.
+    /// - Parameter textInput: UITextInput to convert the range in.
+    func toTextRange(textInput: UITextInput) -> UITextRange? {
+        guard let rangeStart = textInput.position(from: textInput.beginningOfDocument, offset: location),
+            let rangeEnd = textInput.position(from: rangeStart, offset: length) else {
+                return nil
+        }
+        return textInput.textRange(from: rangeStart, to: rangeEnd)
+    }
+
+    /// Checks if the range is valid in given `UITextInput`
+    /// - Parameter textInput: UITextInput to validate the range in.
+    func isValidIn(_ textInput: UITextInput) -> Bool {
+        guard location > 0 else { return false }
+        let end = location + length
+        let contentLength = textInput.offset(from: textInput.beginningOfDocument, to: textInput.endOfDocument)
+        return end < contentLength
+    }
+}

--- a/Slide for Reddit/BannerLinkCellView.swift
+++ b/Slide for Reddit/BannerLinkCellView.swift
@@ -36,8 +36,7 @@ final class BannerLinkCellView: LinkCellView {
                 } else {
                     title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
                 }
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                awardContainerView.bottomAnchor /<=/ bannerImage.topAnchor - ceight / 2 ~ .required
+                title.bottomAnchor /==/ bannerImage.topAnchor - ceight ~ .required
 
                 bannerImage.horizontalAnchors /==/ innerView.horizontalAnchors + bannerPadding
                 
@@ -59,11 +58,9 @@ final class BannerLinkCellView: LinkCellView {
                 }
                 
                 if !SettingValues.actionBarMode.isFull() {
-                    title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                    awardContainerView.bottomAnchor /<=/ innerView.bottomAnchor - ceight / 2 ~ .required
+                    title.bottomAnchor /==/ innerView.bottomAnchor - ceight ~ .required
                 } else {
-                    title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                    awardContainerView.bottomAnchor /==/ box.topAnchor - ceight / 2 ~ .required
+                    title.bottomAnchor /==/ box.topAnchor - ceight ~ .required
                 }
                 
                 bannerImage.topAnchor /==/ innerView.topAnchor + bannerPadding ~ .required

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -212,7 +212,8 @@ class CachedTitle {
         let extraLine = NSMutableAttributedString()
         finalTitle.append(attributedTitle)
         infoLine.append(endString)
-                
+        let fontSize = 12 + CGFloat(SettingValues.postFontOffset)
+
         if !full {
             if SettingValues.scoreInTitle {
                 var sColor = ColorUtil.theme.fontColor.add(overlay: ColorUtil.theme.foregroundColor.withAlphaComponent(0.15))
@@ -246,11 +247,16 @@ class CachedTitle {
                         scoreInt -= 1
                     }
                 }
-                let upvoteImage = NSMutableAttributedString.yy_attachmentString(withEmojiImage: UIImage(sfString: SFSymbol.arrowUp, overrideString: "upvote")!.getCopy(withColor: ColorUtil.theme.fontColor), fontSize: titleFont.pointSize * 0.45)!
-
-                let subScore = NSMutableAttributedString(string: (scoreInt >= 10000 && SettingValues.abbreviateScores) ? String(format: "%0.1fk", (Double(scoreInt) / Double(1000))) : "\(scoreInt)", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: false), NSAttributedString.Key.foregroundColor: sColor])
                 
-                extraLine.append(upvoteImage)
+                let subScore = NSMutableAttributedString(string: (scoreInt >= 10000 && SettingValues.abbreviateScores) ? String(format: " %0.1fk", (Double(scoreInt) / Double(1000))) : "\(scoreInt)", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: false), NSAttributedString.Key.foregroundColor: sColor])
+                let size = subScore.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [], context: nil)
+
+                let image = UIImage(sfString: SFSymbol.arrowUp, overrideString: "upvote")!.getCopy(withSize: CGSize.square(size: size.height * 0.65), withColor: ColorUtil.theme.fontColor)
+                let upvoteImage = NSTextAttachment()
+                upvoteImage.image = image
+                upvoteImage.bounds = CGRect(x: 0, y: (image.size.height * -0.35) / 2, width: image.size.width, height: image.size.height)
+                
+                extraLine.append(NSAttributedString(attachment: upvoteImage))
                 extraLine.append(subScore)
             }
             
@@ -258,11 +264,17 @@ class CachedTitle {
                 if SettingValues.scoreInTitle {
                     extraLine.append(spacer)
                 }
-                let commentImage = NSMutableAttributedString.yy_attachmentString(withEmojiImage: UIImage(sfString: SFSymbol.bubbleRightFill, overrideString: "comments")!.getCopy(withColor: ColorUtil.theme.fontColor), fontSize: titleFont.pointSize * 0.5)!
+                
+                let commentString = NSMutableAttributedString(string: " \(submission.commentCount)", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: false), NSAttributedString.Key.foregroundColor: colorF])
 
-                let scoreString = NSMutableAttributedString(string: "\(submission.commentCount)", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: false), NSAttributedString.Key.foregroundColor: colorF])
-                extraLine.append(commentImage)
-                extraLine.append(scoreString)
+                let size = commentString.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [], context: nil)
+                let commentImage = NSTextAttachment()
+                let image = UIImage(sfString: SFSymbol.bubbleRightFill, overrideString: "comments")!.getCopy(withSize: CGSize.square(size: size.height * 0.75), withColor: ColorUtil.theme.fontColor)
+                commentImage.image = image
+                commentImage.bounds = CGRect(x: 0, y: (image.size.height * -0.25) / 2, width: image.size.width, height: image.size.height)
+
+                extraLine.append(NSAttributedString(attachment: commentImage))
+                extraLine.append(commentString)
             }
         }
         
@@ -286,11 +298,18 @@ class CachedTitle {
             }
             
             let crosspost = NSMutableAttributedString()
-            let crosspostImage = NSTextAttachment()
-            crosspostImage.image = UIImage(named: "crosspost")!.getCopy(withSize: CGSize.square(size: titleFont.pointSize), withColor: ColorUtil.theme.fontColor)
-            crosspost.append(NSAttributedString(attachment: crosspostImage))
-            let finalText = NSMutableAttributedString.init(string: " Crossposted from ", attributes: [NSAttributedString.Key.foregroundColor: colorF, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
             
+            let finalText = NSMutableAttributedString.init(string: " Crossposted from ", attributes: [NSAttributedString.Key.foregroundColor: colorF, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
+            let size = finalText.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [], context: nil)
+            
+            let image = UIImage(named: "crosspost")!.getCopy(withColor: ColorUtil.theme.fontColor).getCopy(withSize: CGSize.square(size: size.height * 0.75), withColor: ColorUtil.theme.fontColor)
+
+            let crosspostImage = NSTextAttachment()
+            crosspostImage.image = image
+            crosspostImage.bounds = CGRect(x: 0, y: (image.size.height * -0.25) / 2, width: image.size.width, height: image.size.height)
+
+            crosspost.append(NSAttributedString(attachment: crosspostImage))
+
             let attrs = [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF] as [NSAttributedString.Key: Any]
             
             let boldString = NSMutableAttributedString(string: "r/\(submission.crosspostSubreddit)", attributes: attrs)
@@ -467,9 +486,7 @@ class CachedTitle {
             iconString.append(tapString)
         } else {
             if color != ColorUtil.baseColor {
-                let adjustedSize = 12 + CGFloat(SettingValues.postFontOffset)
-
-                let preString = NSMutableAttributedString(string: "⬤  ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: adjustedSize), NSAttributedString.Key.foregroundColor: color])
+                let preString = NSMutableAttributedString(string: "⬤  ", attributes: [NSAttributedString.Key.font: titleFont, NSAttributedString.Key.foregroundColor: color])
                 iconString = preString
                 let tapString = NSMutableAttributedString(string: "r/\(link.subreddit)", attributes: attrs)
                 tapString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/r/\(link.subreddit)")!], range: NSRange(location: 0, length: tapString.length))
@@ -603,5 +620,21 @@ extension NSAttributedString {
         let range = NSRange(location: location, length: length)
         return attributedSubstring(from: range)
     }
+}
 
+extension UIImage {
+    func centerImage(with finalSize: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(finalSize, false, self.scale)
+        let _ = UIGraphicsGetCurrentContext()
+        
+        let selfSize = self.size
+        let left = (finalSize.width - selfSize.width) / 2
+        let top = (finalSize.height - selfSize.height) / 2
+        
+        let origin = CGPoint(x: left, y: top)
+        self.draw(at: origin)
+        let imageWithInsets = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return imageWithInsets
+    }
 }

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -183,7 +183,10 @@ class CachedTitle {
             authorAttributes[.badgeColor] = userColor
             authorAttributes[.foregroundColor] = UIColor.white
         }
-        authorAttributes[.urlAction] = URL(string: "https://www.reddit.com/u/\(submission.author)")!
+        
+        if full {
+            authorAttributes[.urlAction] = URL(string: "https://www.reddit.com/u/\(submission.author)")!
+        }
         let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: authorAttributes)
 
         endString.append(authorString)
@@ -412,7 +415,7 @@ class CachedTitle {
             authorAttributes[.badgeColor] = userColor
             authorAttributes[.foregroundColor] = UIColor.white
         }
-        authorAttributes[.urlAction] = URL(string: "https://www.reddit.com/u/\(submission.author)")!
+
         let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: authorAttributes)
 
         endString.append(authorString)

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SDWebImage
 import YYText
 
 struct Title {
@@ -388,10 +389,10 @@ class CachedTitle {
         return rect
     }
 
-    static func getTitleAttributedString(_ link: RSubmission, force: Bool, gallery: Bool, full: Bool, white: Bool = false, loadImages: Bool = true) -> NSAttributedString {
+    static func getTitleAttributedString(_ link: RSubmission, force: Bool, gallery: Bool, full: Bool, white: Bool = false, loadImages: Bool = true, textView: UITextView? = nil) -> NSAttributedString {
         let titleStrings = CachedTitle.getTitle(submission: link, full: full, force, white, gallery: gallery)
-        
-        let attrs = [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: titleStrings.color] as [NSAttributedString.Key: Any]
+        let titleFont = FontGenerator.boldFontOfSize(size: 12, submission: true)
+        let attrs = [NSAttributedString.Key.font: titleFont, NSAttributedString.Key.foregroundColor: titleStrings.color] as [NSAttributedString.Key: Any]
         
         let color = ColorUtil.getColorForSub(sub: link.subreddit)
 
@@ -402,15 +403,10 @@ class CachedTitle {
             }
             if let urlAsURL = URL(string: Subscriptions.icon(for: link.subreddit.lowercased())!.unescapeHTML) {
                 if loadImages {
-                    let flairView = UIImageView(frame: CGRect(x: 0, y: 3, width: 20 + SettingValues.postFontOffset, height: 20 + SettingValues.postFontOffset))
-                    flairView.layer.cornerRadius = CGFloat(20 + SettingValues.postFontOffset) / 2
-                    flairView.layer.borderColor = color.cgColor
-                    flairView.backgroundColor = color
-                    flairView.layer.borderWidth = 0.5
-                    flairView.clipsToBounds = true
-                    flairView.sd_setImage(with: urlAsURL, placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: flairView.frame.size.width * UIScreen.main.scale, height: flairView.frame.size.height * UIScreen.main.scale)])
-                    let flairImage = NSMutableAttributedString.yy_attachmentString(withContent: flairView, contentMode: UIView.ContentMode.center, attachmentSize: CGSize(width: 20 + SettingValues.postFontOffset, height: 20 + SettingValues.postFontOffset), alignTo: CachedTitle.titleFont, alignment: YYTextVerticalAlignment.center)
-                    iconString.append(flairImage)
+                    var attachment = NSTextAttachment()
+                    attachment.image = UIImage()
+                    attachment.bounds = CGRect(x: 0, y: (titleFont.capHeight - 24) + 5, width: 24, height: 5)
+                    iconString.append(NSAttributedString(attachment: attachment))
                 } else {
                     let flairView = UIView(frame: CGRect(x: 0, y: 3, width: 20 + SettingValues.postFontOffset, height: 20 + SettingValues.postFontOffset))
                     let flairImage = NSMutableAttributedString.yy_attachmentString(withContent: flairView, contentMode: UIView.ContentMode.center, attachmentSize: CGSize(width: 20 + SettingValues.postFontOffset, height: 20 + SettingValues.postFontOffset), alignTo: CachedTitle.titleFont, alignment: YYTextVerticalAlignment.center)

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -165,30 +165,36 @@ class CachedTitle {
 
         let endString = NSMutableAttributedString(string: "  •  \(DateFormatter().timeSince(from: submission.created, numericDates: true))\((submission.isEdited ? ("(edit \(DateFormatter().timeSince(from: submission.edited, numericDates: true)))") : ""))  •  ", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
-        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
-
+        var authorAttributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF]
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#E57373"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#E57373")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if submission.distinguished == "special" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#F44336"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#F44336")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if submission.distinguished == "moderator" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#81C784"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#81C784")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if AccountController.currentName == submission.author {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#FFB74D")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key.badgeColor: userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = userColor
+            authorAttributes[.foregroundColor] = UIColor.white
         }
-        authorString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/u/\(submission.author)")!], range: NSRange(location: 0, length: authorString.length))
+        authorAttributes[.urlAction] = URL(string: "https://www.reddit.com/u/\(submission.author)")!
+        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: authorAttributes)
 
         endString.append(authorString)
+        
         if SettingValues.domainInInfo && !full {
             endString.append(NSAttributedString.init(string: "  •  \(submission.domain)", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF]))
         }
 
         let tag = ColorUtil.getTagForUser(name: submission.author)
         if tag != nil {
-            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor(rgb: 0x2196f3), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: UIColor(rgb: 0x2196f3), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             endString.append(spacer)
             endString.append(tagString)
@@ -354,14 +360,14 @@ class CachedTitle {
         let attributedTitle = NSMutableAttributedString(string: submission.title.unescapeHTML, attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.foregroundColor: colorF])
 
         if submission.nsfw {
-            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor:GMColor.red500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor: GMColor.red500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             attributedTitle.append(spacer)
             attributedTitle.append(nsfw)
         }
 
         if submission.oc {
-            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor:GMColor.blue50Color(), NSAttributedString.Key.foregroundColor: UIColor.black])
+            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor: GMColor.blue50Color(), NSAttributedString.Key.foregroundColor: UIColor.black])
 
             attributedTitle.append(spacer)
             attributedTitle.append(oc)
@@ -369,26 +375,32 @@ class CachedTitle {
 
         let endString = NSMutableAttributedString(string: "r/\(submission.subreddit)  •  \(DateFormatter().timeSince(from: submission.created, numericDates: true))\((submission.isEdited ? ("(edit \(DateFormatter().timeSince(from: submission.edited, numericDates: true)))") : ""))  •  ", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
-        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
-
+        var authorAttributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF]
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#E57373"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#E57373")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if submission.distinguished == "special" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#F44336"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#F44336")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if submission.distinguished == "moderator" {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#81C784"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#81C784")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if AccountController.currentName == submission.author {
-            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = UIColor.init(hexString: "#FFB74D")
+            authorAttributes[.foregroundColor] = UIColor.white
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key.badgeColor: userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorAttributes[.badgeColor] = userColor
+            authorAttributes[.foregroundColor] = UIColor.white
         }
+        authorAttributes[.urlAction] = URL(string: "https://www.reddit.com/u/\(submission.author)")!
+        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: authorAttributes)
 
         endString.append(authorString)
 
         let tag = ColorUtil.getTagForUser(name: submission.author)
         if tag != nil {
-            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor(rgb: 0x2196f3), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: UIColor(rgb: 0x2196f3), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             endString.append(spacer)
             endString.append(tagString)
@@ -477,7 +489,13 @@ class CachedTitle {
             finalTitle.append(NSAttributedString.init(string: "\n"))
             finalTitle.append(iconString)
             if let infoLine = titleStrings.infoLine {
-                finalTitle.append(NSAttributedString(string: infoLine.string, attributes: attrs))
+                if let baseline = attrs[.baselineOffset] {
+                    let mutableLine = NSMutableAttributedString(attributedString: infoLine)
+                    mutableLine.addAttributes([.baselineOffset: baseline], range: NSRange(location: 0, length: infoLine.length))
+                    finalTitle.append(mutableLine)
+                } else {
+                    finalTitle.append(infoLine)
+                }
             }
             if let extraLine = titleStrings.extraLine, extraLine.length > 0 {
                 finalTitle.append(NSAttributedString.init(string: "\n"))
@@ -486,7 +504,13 @@ class CachedTitle {
         } else {
             finalTitle.append(iconString)
             if let infoLine = titleStrings.infoLine {
-                finalTitle.append(NSAttributedString(string: infoLine.string, attributes: attrs))
+                if let baseline = attrs[.baselineOffset] {
+                    let mutableLine = NSMutableAttributedString(attributedString: infoLine)
+                    mutableLine.addAttributes([.baselineOffset: baseline], range: NSRange(location: 0, length: infoLine.length))
+                    finalTitle.append(mutableLine)
+                } else {
+                    finalTitle.append(infoLine)
+                }
             }
             finalTitle.append(NSAttributedString.init(string: "\n"))
             if let mainTitle = titleStrings.mainTitle {
@@ -556,7 +580,7 @@ class CachedTitle {
                 awardLine.addAttributes([.urlAction: URL(string: CachedTitle.AWARD_KEY)!], range: NSRange(location: 0, length: awardLine.length)) //We will catch this URL later on
 
                 finalTitle.append(awardLine)
-                finalTitle.append(NSAttributedString(string: "")) //Stop tap from going to the end of the view width
+                finalTitle.append(NSAttributedString(string: " ")) //Stop tap from going to the end of the view width
             }
         }
         return finalTitle

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -577,13 +577,12 @@ class CachedTitle {
                             if loadImages {
                                 let size = testString.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [], context: nil)
 
-
                                 let attachment = AsyncTextAttachment(imageURL: urlAsURL, delegate: nil, rounded: false, backgroundColor: ColorUtil.theme.foregroundColor)
-                                attachment.bounds = CGRect(x: 0, y: (15 * -0.25) / 2, width: 15, height: 15)
+                                attachment.bounds = CGRect(x: 0, y: (15 * -0.5) / 2, width: 15, height: 15)
                                 attachments.append(attachment)
                             } else {
                                 let attachment = NSTextAttachment()
-                                attachment.bounds = CGRect(x: 0, y: (15 * -0.25) / 2, width: 15, height: 15)
+                                attachment.bounds = CGRect(x: 0, y: (15 * -0.5) / 2, width: 15, height: 15)
                                 attachments.append(attachment)
                             }
                         }

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -19,6 +19,7 @@ struct Title {
 }
 
 class CachedTitle {
+    static var AWARD_KEY = "https://ccrama.me/awards"
     static var titles: [String: Title] = [:]
     static var removed: [String] = []
     static var approved: [String] = []
@@ -164,8 +165,7 @@ class CachedTitle {
 
         let endString = NSMutableAttributedString(string: "  •  \(DateFormatter().timeSince(from: submission.created, numericDates: true))\((submission.isEdited ? ("(edit \(DateFormatter().timeSince(from: submission.edited, numericDates: true)))") : ""))  •  ", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
-        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author + (submission.cakeday ? " 🎂" : ""), small: false))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
-        authorString.yy_setTextHighlight(NSRange(location: 0, length: authorString.length), color: nil, backgroundColor: nil, userInfo: ["url": URL(string: "/u/\(submission.author)")!, "profile": submission.author])
+        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
@@ -177,8 +177,9 @@ class CachedTitle {
         } else if AccountController.currentName == submission.author {
             authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key.badgeColor:userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.badgeColor: userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         }
+        authorString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/u/\(submission.author)")!], range: NSRange(location: 0, length: authorString.length))
 
         endString.append(authorString)
         if SettingValues.domainInInfo && !full {
@@ -368,8 +369,7 @@ class CachedTitle {
 
         let endString = NSMutableAttributedString(string: "r/\(submission.subreddit)  •  \(DateFormatter().timeSince(from: submission.created, numericDates: true))\((submission.isEdited ? ("(edit \(DateFormatter().timeSince(from: submission.edited, numericDates: true)))") : ""))  •  ", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
-        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author + (submission.cakeday ? " 🎂" : ""), small: false))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
-        authorString.yy_setTextHighlight(NSRange(location: 0, length: authorString.length), color: nil, backgroundColor: nil, userInfo: ["url": URL(string: "/u/\(submission.author)")!, "profile": submission.author])
+        let authorString = NSMutableAttributedString(string: "\u{00A0}\(AccountController.formatUsername(input: submission.author, small: false) + (submission.cakeday ? " 🎂" : ""))\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
@@ -381,7 +381,7 @@ class CachedTitle {
         } else if AccountController.currentName == submission.author {
             authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key.badgeColor:userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.badgeColor: userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         }
 
         endString.append(authorString)
@@ -394,7 +394,6 @@ class CachedTitle {
             endString.append(tagString)
         }
         
-                
         let extraLine = NSMutableAttributedString()
                         
         return Title(mainTitle: attributedTitle, infoLine: endString, extraLine: extraLine, color: UIColor.white)
@@ -451,7 +450,8 @@ class CachedTitle {
                 }
             }
             let tapString = NSMutableAttributedString(string: "  r/\(link.subreddit)", attributes: attrs)
-            tapString.yy_setTextHighlight(NSRange(location: 0, length: tapString.length), color: nil, backgroundColor: nil, userInfo: ["url": URL(string: "/r/\(link.subreddit)")!])
+            tapString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/r/\(link.subreddit)")!], range: NSRange(location: 0, length: tapString.length))
+
             iconString.append(tapString)
         } else {
             if color != ColorUtil.baseColor {
@@ -460,11 +460,11 @@ class CachedTitle {
                 let preString = NSMutableAttributedString(string: "⬤  ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: adjustedSize), NSAttributedString.Key.foregroundColor: color])
                 iconString = preString
                 let tapString = NSMutableAttributedString(string: "r/\(link.subreddit)", attributes: attrs)
-                tapString.yy_setTextHighlight(NSRange(location: 0, length: tapString.length), color: nil, backgroundColor: nil, userInfo: ["url": URL(string: "/r/\(link.subreddit)")!])
+                tapString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/r/\(link.subreddit)")!], range: NSRange(location: 0, length: tapString.length))
                 iconString.append(tapString)
             } else {
                 let tapString = NSMutableAttributedString(string: "r/\(link.subreddit)", attributes: attrs)
-                tapString.yy_setTextHighlight(NSRange(location: 0, length: tapString.length), color: nil, backgroundColor: nil, userInfo: ["url": URL(string: "/r/\(link.subreddit)")!])
+                tapString.addAttributes([.urlAction: URL(string: "https://www.reddit.com/r/\(link.subreddit)")!], range: NSRange(location: 0, length: tapString.length))
                 iconString = tapString
             }
         }
@@ -553,8 +553,10 @@ class CachedTitle {
                     awardLine.append(NSMutableAttributedString(string: "\(awardCount) Awards", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.fontColor, NSAttributedString.Key.baselineOffset: (((24 - fontSize) / 2) - (titleFont.descender / 2))]))
                 }
                 
+                awardLine.addAttributes([.urlAction: URL(string: CachedTitle.AWARD_KEY)!], range: NSRange(location: 0, length: awardLine.length)) //We will catch this URL later on
 
                 finalTitle.append(awardLine)
+                finalTitle.append(NSAttributedString(string: "")) //Stop tap from going to the end of the view width
             }
         }
         return finalTitle

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SDWebImage
+import Proton
 import YYText
 
 struct Title {
@@ -69,60 +70,100 @@ class CachedTitle {
         }
         let attributedTitle = NSMutableAttributedString(string: submission.title.unescapeHTML, attributes: [NSAttributedString.Key.font: titleFont, NSAttributedString.Key.foregroundColor: brightF])
 
+        var newlineDone = false
         if !submission.flair.isEmpty {
-            let flairTitle = NSMutableAttributedString.init(string: "\u{00A0}\(submission.flair)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: ColorUtil.theme.backgroundColor, cornerRadius: 3), NSAttributedString.Key.foregroundColor: brightF])
+            let flairTitle = NSMutableAttributedString.init(string: "\u{00A0}\(submission.flair)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: ColorUtil.theme.backgroundColor, NSAttributedString.Key.foregroundColor: brightF])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(flairTitle)
         }
         
         if submission.nsfw {
-            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.red500Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: GMColor.red500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(nsfw)
         }
 
         if submission.spoiler {
-            let spoiler = NSMutableAttributedString.init(string: "\u{00A0}SPOILER\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.grey50Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.black])
+            let spoiler = NSMutableAttributedString.init(string: "\u{00A0}SPOILER\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: GMColor.grey50Color(), NSAttributedString.Key.foregroundColor: UIColor.black])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(spoiler)
         }
 
         if submission.oc {
-            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.blue50Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.black])
+            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: GMColor.blue50Color(), NSAttributedString.Key.foregroundColor: UIColor.black])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(oc)
         }
 
-        
-        /*if submission.cakeday {
-            attributedTitle.append(spacer)
-            let gild = NSMutableAttributedString(string: "🍰", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
-            attributedTitle.append(gild)
-        }*/
-
         if submission.stickied {
-            let pinned = NSMutableAttributedString.init(string: "\u{00A0}PINNED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.green500Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let pinned = NSMutableAttributedString.init(string: "\u{00A0}PINNED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: GMColor.green500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(pinned)
         }
 
         if submission.locked {
-            let locked = NSMutableAttributedString.init(string: "\u{00A0}LOCKED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.green500Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let locked = NSMutableAttributedString.init(string: "\u{00A0}LOCKED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: GMColor.green500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
 
-            attributedTitle.append(spacer)
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
             attributedTitle.append(locked)
         }
         if submission.archived {
-            let archived = NSMutableAttributedString.init(string: "\u{00A0}ARCHIVED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: ColorUtil.theme.backgroundColor, cornerRadius: 3), NSAttributedString.Key.foregroundColor: brightF])
+            let archived = NSMutableAttributedString.init(string: "\u{00A0}ARCHIVED\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: ColorUtil.theme.backgroundColor, NSAttributedString.Key.foregroundColor: brightF])
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
 
             attributedTitle.append(archived)
         }
-
+        
+        if SettingValues.typeInTitle {
+            let info = NSMutableAttributedString.init(string: "\u{00A0}\(submission.type.rawValue)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.badgeColor: ColorUtil.theme.fontColor, NSAttributedString.Key.foregroundColor: ColorUtil.theme.foregroundColor])
+            if !newlineDone {
+                newlineDone = true
+                attributedTitle.append(NSAttributedString(string: "\n"))
+            } else {
+                attributedTitle.append(spacer)
+            }
+            attributedTitle.append(info)
+        }
 
         let endString = NSMutableAttributedString(string: "  •  \(DateFormatter().timeSince(from: submission.created, numericDates: true))\((submission.isEdited ? ("(edit \(DateFormatter().timeSince(from: submission.edited, numericDates: true)))") : ""))  •  ", attributes: [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF])
 
@@ -131,15 +172,15 @@ class CachedTitle {
 
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#E57373"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#E57373"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if submission.distinguished == "special" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#F44336"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#F44336"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if submission.distinguished == "moderator" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#81C784"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#81C784"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if AccountController.currentName == submission.author {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: userColor, cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.badgeColor:userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         }
 
         endString.append(authorString)
@@ -149,7 +190,7 @@ class CachedTitle {
 
         let tag = ColorUtil.getTagForUser(name: submission.author)
         if tag != nil {
-            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor(rgb: 0x2196f3), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor(rgb: 0x2196f3), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             endString.append(spacer)
             endString.append(tagString)
@@ -235,12 +276,6 @@ class CachedTitle {
             extraLine.append(NSMutableAttributedString.init(string: "Approved\(!submission.approvedBy.isEmpty() ? " by \(submission.approvedBy)":"")", attributes: attrs))
         }
         
-        if SettingValues.typeInTitle {
-            let info = NSMutableAttributedString.init(string: "\u{00A0}\u{00A0}\(submission.type.rawValue)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: ColorUtil.theme.fontColor, cornerRadius: 3), NSAttributedString.Key.foregroundColor: ColorUtil.theme.foregroundColor])
-            finalTitle.append(spacer)
-            finalTitle.append(info)
-        }
-
         if submission.isCrosspost && !full {
             if extraLine.string.length > 0 {
                 extraLine.append(NSAttributedString.init(string: "\n"))
@@ -318,14 +353,14 @@ class CachedTitle {
         let attributedTitle = NSMutableAttributedString(string: submission.title.unescapeHTML, attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.foregroundColor: colorF])
 
         if submission.nsfw {
-            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.red500Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let nsfw = NSMutableAttributedString.init(string: "\u{00A0}NSFW\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor:GMColor.red500Color(), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             attributedTitle.append(spacer)
             attributedTitle.append(nsfw)
         }
 
         if submission.oc {
-            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: GMColor.blue50Color(), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.black])
+            let oc = NSMutableAttributedString.init(string: "\u{00A0}OC\u{00A0}", attributes: [NSAttributedString.Key.font: titleFontSmall, NSAttributedString.Key.badgeColor:GMColor.blue50Color(), NSAttributedString.Key.foregroundColor: UIColor.black])
 
             attributedTitle.append(spacer)
             attributedTitle.append(oc)
@@ -338,22 +373,22 @@ class CachedTitle {
 
         let userColor = ColorUtil.getColorForUser(name: submission.author)
         if submission.distinguished == "admin" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#E57373"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#E57373"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if submission.distinguished == "special" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#F44336"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#F44336"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if submission.distinguished == "moderator" {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#81C784"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#81C784"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if AccountController.currentName == submission.author {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor.init(hexString: "#FFB74D"), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         } else if userColor != ColorUtil.baseColor {
-            authorString.addAttributes([NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: userColor, cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
+            authorString.addAttributes([NSAttributedString.Key.badgeColor:userColor, NSAttributedString.Key.foregroundColor: UIColor.white], range: NSRange.init(location: 0, length: authorString.length))
         }
 
         endString.append(authorString)
 
         let tag = ColorUtil.getTagForUser(name: submission.author)
         if tag != nil {
-            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key(rawValue: YYTextBackgroundBorderAttributeName): YYTextBorder(fill: UIColor(rgb: 0x2196f3), cornerRadius: 3), NSAttributedString.Key.foregroundColor: UIColor.white])
+            let tagString = NSMutableAttributedString.init(string: "\u{00A0}\(tag!)\u{00A0}", attributes: [NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true), NSAttributedString.Key.backgroundStyle: BackgroundStyle(color: UIColor(rgb: 0x2196f3), cornerRadius: 3, border: nil, shadow: nil), NSAttributedString.Key.foregroundColor: UIColor.white])
 
             endString.append(spacer)
             endString.append(tagString)
@@ -389,9 +424,9 @@ class CachedTitle {
         return rect
     }
 
-    static func getTitleAttributedString(_ link: RSubmission, force: Bool, gallery: Bool, full: Bool, white: Bool = false, loadImages: Bool = true, textView: UITextView? = nil) -> NSAttributedString {
+    static func getTitleAttributedString(_ link: RSubmission, force: Bool, gallery: Bool, full: Bool, white: Bool = false, loadImages: Bool = true) -> NSAttributedString {
         let titleStrings = CachedTitle.getTitle(submission: link, full: full, force, white, gallery: gallery)
-        var fontSize = 12 + CGFloat(SettingValues.postFontOffset)
+        let fontSize = 12 + CGFloat(SettingValues.postFontOffset)
         let titleFont = FontGenerator.boldFontOfSize(size: 12, submission: true)
         var attrs = [NSAttributedString.Key.font: titleFont, NSAttributedString.Key.foregroundColor: titleStrings.color] as [NSAttributedString.Key: Any]
         
@@ -404,12 +439,12 @@ class CachedTitle {
             }
             if let urlAsURL = URL(string: Subscriptions.icon(for: link.subreddit.lowercased())!.unescapeHTML) {
                 if loadImages {
-                    var attachment = AsyncTextAttachment(imageURL: urlAsURL, delegate: nil, rounded: true, backgroundColor: color)
+                    let attachment = AsyncTextAttachment(imageURL: urlAsURL, delegate: nil, rounded: true, backgroundColor: color)
                     attachment.bounds = CGRect(x: 0, y: 0, width: 24, height: 24)
                     iconString.append(NSAttributedString(attachment: attachment))
                     attrs[.baselineOffset] = (((24 - fontSize) / 2) - (titleFont.descender / 2))
                 } else {
-                    var attachment = NSTextAttachment()
+                    let attachment = NSTextAttachment()
                     attachment.bounds = CGRect(x: 0, y: 0, width: 24, height: 24)
                     iconString.append(NSAttributedString(attachment: attachment))
                     attrs[.baselineOffset] = (((24 - fontSize) / 2) - (titleFont.descender / 2))

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -572,21 +572,25 @@ class CachedTitle {
                         totalAwards += 1
 
                         let url = award[1]
+                        let testString = NSMutableAttributedString(string: "test", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.fontColor])
                         if let urlAsURL = URL(string: url) {
                             if loadImages {
+                                let size = testString.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [], context: nil)
+
+
                                 let attachment = AsyncTextAttachment(imageURL: urlAsURL, delegate: nil, rounded: false, backgroundColor: ColorUtil.theme.foregroundColor)
-                                attachment.bounds = CGRect(x: 0, y: (24 - 15) / 2, width: 15, height: 15)
+                                attachment.bounds = CGRect(x: 0, y: (15 * -0.25) / 2, width: 15, height: 15)
                                 attachments.append(attachment)
                             } else {
                                 let attachment = NSTextAttachment()
-                                attachment.bounds = CGRect(x: 0, y: (24 - 15) / 2, width: 15, height: 15)
+                                attachment.bounds = CGRect(x: 0, y: (15 * -0.25) / 2, width: 15, height: 15)
                                 attachments.append(attachment)
                             }
                         }
                     }
                 }
                 
-                let awardLine = NSMutableAttributedString(string: "\n\n", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.foregroundColor])
+                let awardLine = NSMutableAttributedString(string: "\n", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.foregroundColor])
 
                 for award in attachments {
                     awardLine.append(NSAttributedString(attachment: award))
@@ -594,13 +598,13 @@ class CachedTitle {
                 }
                 
                 if totalAwards == to {
-                    awardLine.append(NSMutableAttributedString(string: "\(awardCount) Awards", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.fontColor, NSAttributedString.Key.baselineOffset: (((24 - fontSize) / 2) - (titleFont.descender / 2))]))
+                    awardLine.append(NSMutableAttributedString(string: "\(awardCount) Awards", attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: ColorUtil.theme.fontColor]))
                 }
                 
-                awardLine.addAttributes([.urlAction: URL(string: CachedTitle.AWARD_KEY)!], range: NSRange(location: 0, length: awardLine.length)) //We will catch this URL later on
+                awardLine.addAttributes([.urlAction: URL(string: CachedTitle.AWARD_KEY)!], range: NSRange(location: 2, length: awardLine.length - 2)) //We will catch this URL later on, start it after the newline
 
                 finalTitle.append(awardLine)
-                finalTitle.append(NSAttributedString(string: " ")) //Stop tap from going to the end of the view width
+                finalTitle.append(NSAttributedString(string: "\u{00A0}")) //Stop tap from going to the end of the view width
             }
         }
         return finalTitle

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -281,8 +281,10 @@ class CachedTitle {
                 extraLine.append(NSAttributedString.init(string: "\n"))
             }
             
-            let crosspost = NSMutableAttributedString.yy_attachmentString(withEmojiImage: UIImage(named: "crosspost")!.getCopy(withColor: ColorUtil.theme.fontColor), fontSize: titleFont.pointSize * 0.75)!
-
+            let crosspost = NSMutableAttributedString()
+            let crosspostImage = NSTextAttachment()
+            crosspostImage.image = UIImage(named: "crosspost")!.getCopy(withSize: CGSize.square(size: titleFont.pointSize), withColor: ColorUtil.theme.fontColor)
+            crosspost.append(NSAttributedString(attachment: crosspostImage))
             let finalText = NSMutableAttributedString.init(string: " Crossposted from ", attributes: [NSAttributedString.Key.foregroundColor: colorF, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
             
             let attrs = [NSAttributedString.Key.font: FontGenerator.fontOfSize(size: 12, submission: true), NSAttributedString.Key.foregroundColor: colorF] as [NSAttributedString.Key: Any]

--- a/Slide for Reddit/CachedTitle.swift
+++ b/Slide for Reddit/CachedTitle.swift
@@ -346,7 +346,7 @@ class CachedTitle {
 
             if !text.isEmpty() {
                 extraLine.append(NSAttributedString.init(string: "\n")) //Extra space for body
-                extraLine.append(TextDisplayStackView.createAttributedChunk(baseHTML: text.unescapeHTML.replacingOccurrences(of: "<p>", with: "").replacingOccurrences(of: "</p>", with: ""), fontSize: 14, submission: false, accentColor: ColorUtil.accentColorForSub(sub: submission.subreddit), fontColor: ColorUtil.theme.fontColor, linksCallback: nil, indexCallback: nil))
+                extraLine.append(TextDisplayStackView.createAttributedChunk(baseHTML: text.replacingOccurrences(of: "<!-- SC_OFF -->", with: "").replacingOccurrences(of: "<p>", with: "").replacingOccurrences(of: "</p>", with: ""), fontSize: 14, submission: false, accentColor: ColorUtil.accentColorForSub(sub: submission.subreddit), fontColor: ColorUtil.theme.fontColor, linksCallback: nil, indexCallback: nil).trimWhiteSpace())
             }
         }
         
@@ -584,6 +584,24 @@ class CachedTitle {
             }
         }
         return finalTitle
+    }
+}
+
+extension NSAttributedString {
+
+    /** Will Trim space and new line from start and end of the text */
+    public func trimWhiteSpace() -> NSAttributedString {
+        let invertedSet = CharacterSet.whitespacesAndNewlines.inverted
+        let startRange = string.utf16.description.rangeOfCharacter(from: invertedSet)
+        let endRange = string.utf16.description.rangeOfCharacter(from: invertedSet, options: .backwards)
+        guard let startLocation = startRange?.upperBound, let endLocation = endRange?.lowerBound else {
+            return NSAttributedString(string: string)
+        }
+
+        let location = string.utf16.distance(from: string.startIndex, to: startLocation) - 1
+        let length = string.utf16.distance(from: startLocation, to: endLocation) + 2
+        let range = NSRange(location: location, length: length)
+        return attributedSubstring(from: range)
     }
 
 }

--- a/Slide for Reddit/ColorUtil.swift
+++ b/Slide for Reddit/ColorUtil.swift
@@ -116,7 +116,7 @@ public class ColorUtil {
         if header && SettingValues.reduceColor {
             return ColorUtil.theme.foregroundColor
         }
-        if let color = Subscriptions.color(for: sub) {
+        if let color = Subscriptions.color(for: sub), color != .white, color != .black {
             return color
         } else if let color = UserDefaults.standard.colorForKey(key: "color+" + sub) {
             return color

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -1430,8 +1430,12 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, *) {
             if #available(iOS 14.0, *) {
-                if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
-                    ColorUtil.matchTraitCollection()
+                if UIDevice.current.userInterfaceIdiom == .pad {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { //Wait for 0.1 seconds. There is a race condition here that sets the theme twice on iPad
+                        if previousTraitCollection?.userInterfaceStyle != self.traitCollection.userInterfaceStyle {
+                            ColorUtil.matchTraitCollection()
+                        }
+                    }
                 }
             } else {
                 if let themeChanged = previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) {

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -131,10 +131,10 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
                 }
                 jump.addSubview(image)
                 image.edgeAnchors /==/ jump.edgeAnchors
-                jump.addTapGestureRecognizer {
+                jump.addTapGestureRecognizer { (_) in
                     self.goDown(self.jump)
                 }
-                jump.addLongTapGestureRecognizer {
+                jump.addLongTapGestureRecognizer { (_) in
                     self.goUp(self.jump)
                 }
             }
@@ -324,7 +324,7 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
                                                 $0.layer.cornerRadius = 20
                                                 $0.clipsToBounds = true
                                                 $0.textAlignment = .center
-                                                $0.addTapGestureRecognizer {
+                                                $0.addTapGestureRecognizer { (_) in
                                                     UIView.animate(withDuration: 0.3, delay: 0, options: UIView.AnimationOptions.curveEaseInOut, animations: {
                                                         self.tableView.contentOffset.y = (self.tableView.tableHeaderView?.frame.size.height ?? 60) + 64
                                                     }, completion: { (_) in
@@ -1118,7 +1118,7 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
         label.accessibilityHint = "Opens the sub red it r \(sub)"
         label.accessibilityLabel = "Sub red it: r \(sub)"
 
-        label.addTapGestureRecognizer(action: {
+        label.addTapGestureRecognizer(action: { (_) in
             VCPresenter.openRedditLink("/r/\(sub)", self.navigationController, self)
         })
         

--- a/Slide for Reddit/CommentViewController.swift
+++ b/Slide for Reddit/CommentViewController.swift
@@ -1665,6 +1665,9 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        fullWidthBackGestureRecognizer?.isEnabled = true
+        cellGestureRecognizer?.isEnabled = true
+
         refreshControl.setValue(100, forKey: "_snappingHeight")
 
         if UIScreen.main.traitCollection.userInterfaceIdiom == .pad && Int(round(self.view.bounds.width / CGFloat(320))) > 1 && false {
@@ -2259,6 +2262,9 @@ class CommentViewController: MediaViewController, UITableViewDelegate, UITableVi
         inHeadView.removeFromSuperview()
         headerCell.endVideos()
         
+        fullWidthBackGestureRecognizer?.isEnabled = false
+        cellGestureRecognizer?.isEnabled = false
+
         self.didDisappearCompletely = true
     }
 
@@ -3230,6 +3236,7 @@ extension CommentViewController: UIGestureRecognizerDelegate {
         }
         if let nav = self.navigationController as? SwipeForwardNavigationController {
             nav.fullWidthBackGestureRecognizer.require(toFail: cellGestureRecognizer)
+            nav.interactivePushGestureRecognizer?.require(toFail: cellGestureRecognizer)
             if let interactivePop = nav.interactivePopGestureRecognizer {
                 cellGestureRecognizer.require(toFail: interactivePop)
             }
@@ -3274,6 +3281,11 @@ extension CommentViewController: UIGestureRecognizerDelegate {
             if let interactivePopGestureRecognizer = self.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets") {
                 setupSwipeWithTarget(fullWidthBackGestureRecognizer, interactivePopGestureRecognizer: interactivePopGestureRecognizer, targets: targets)
             }
+        }
+        if let nav = navigationController as? SwipeForwardNavigationController {
+            let gesture = nav.fullWidthBackGestureRecognizer
+            nav.interactivePushGestureRecognizer?.require(toFail: fullWidthBackGestureRecognizer)
+            gesture.require(toFail: fullWidthBackGestureRecognizer)
         }
     }
 

--- a/Slide for Reddit/ContentListingViewController.swift
+++ b/Slide for Reddit/ContentListingViewController.swift
@@ -286,10 +286,7 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
             c?.del = self
             
             (c)!.configure(submission: thing as! RSubmission, parent: self, nav: self.navigationController, baseSub: "", np: false)
-            
-            c?.layer.shouldRasterize = true
-            c?.layer.rasterizationScale = UIScreen.main.scale
-            
+                        
             if self is ReadLaterViewController {
                 c?.readLater.isHidden = false
             }
@@ -298,27 +295,19 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         } else if thing is RComment {
             let c = tableView.dequeueReusableCell(withReuseIdentifier: "comment", for: indexPath) as! CommentCellView
             c.setComment(comment: (thing as! RComment), parent: self, nav: self.navigationController, width: self.view.frame.size.width)
-            c.layer.shouldRasterize = true
-            c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
         } else if thing is RFriend {
             let c = tableView.dequeueReusableCell(withReuseIdentifier: "friend", for: indexPath) as! FriendCellView
             c.setFriend(friend: (thing as! RFriend), parent: self)
-            c.layer.shouldRasterize = true
-            c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
         } else if thing is RMessage {
             let c = tableView.dequeueReusableCell(withReuseIdentifier: "message", for: indexPath) as! MessageCellView
             c.setMessage(message: (thing as! RMessage), parent: self, nav: self.navigationController, width: self.view.frame.size.width)
-            c.layer.shouldRasterize = true
-            c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
         } else {
             //Is mod log item
             let c = tableView.dequeueReusableCell(withReuseIdentifier: "modlog", for: indexPath) as! ModlogCellView
             c.setLogItem(logItem: (thing as! RModlogItem), parent: self, nav: self.navigationController, width: self.view.frame.size.width)
-            c.layer.shouldRasterize = true
-            c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
         }
         

--- a/Slide for Reddit/ContentListingViewController.swift
+++ b/Slide for Reddit/ContentListingViewController.swift
@@ -72,6 +72,9 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         for index in tableView.indexPathsForVisibleItems {
             if let cell = tableView.cellForItem(at: index) as? LinkCellView {
                 cell.endVideos()
+                self.currentPlayingIndex = self.currentPlayingIndex.filter({ (included) -> Bool in
+                    return included.row != index.row
+                })
             }
         }
     }
@@ -279,7 +282,11 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
             case .autoplay:
                 c = tableView.dequeueReusableCell(withReuseIdentifier: "autoplay", for: indexPath) as! AutoplayBannerLinkCellView
             default:
-                c = tableView.dequeueReusableCell(withReuseIdentifier: "text", for: indexPath) as! TextLinkCellView
+                if !SettingValues.hideImageSelftext && (thing as! RSubmission).height > 0 {
+                    c = tableView.dequeueReusableCell(withReuseIdentifier: "banner", for: indexPath) as! BannerLinkCellView
+                } else {
+                    c = tableView.dequeueReusableCell(withReuseIdentifier: "text", for: indexPath) as! TextLinkCellView
+                }
             }
             
             c?.preservesSuperviewLayoutMargins = false
@@ -449,8 +456,21 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
     }
     
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if cell is LinkCellView && (cell as! LinkCellView).videoView != nil {
-            (cell as! LinkCellView).endVideos()
+        if let cell = cell as? AutoplayBannerLinkCellView {
+            if cell.videoView != nil {
+                cell.endVideos()
+                self.currentPlayingIndex = self.currentPlayingIndex.filter({ (included) -> Bool in
+                    return included.row != indexPath.row
+                })
+            }
+        }
+        if let cell = cell as? GalleryLinkCellView {
+            if cell.videoView != nil {
+                cell.endVideos()
+                self.currentPlayingIndex = self.currentPlayingIndex.filter({ (included) -> Bool in
+                    return included.row != indexPath.row
+                })
+            }
         }
     }
     

--- a/Slide for Reddit/ContentListingViewController.swift
+++ b/Slide for Reddit/ContentListingViewController.swift
@@ -204,6 +204,7 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
         self.tableView.register(TextLinkCellView.classForCoder(), forCellWithReuseIdentifier: "text")
         self.tableView.register(CommentCellView.classForCoder(), forCellWithReuseIdentifier: "comment")
         self.tableView.register(MessageCellView.classForCoder(), forCellWithReuseIdentifier: "message")
+        self.tableView.register(ModlogCellView.classForCoder(), forCellWithReuseIdentifier: "modlog")
         self.tableView.register(FriendCellView.classForCoder(), forCellWithReuseIdentifier: "friend")
         tableView.backgroundColor = ColorUtil.theme.backgroundColor
         
@@ -306,9 +307,16 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
             c.layer.shouldRasterize = true
             c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
-        } else {
+        } else if thing is RMessage {
             let c = tableView.dequeueReusableCell(withReuseIdentifier: "message", for: indexPath) as! MessageCellView
             c.setMessage(message: (thing as! RMessage), parent: self, nav: self.navigationController, width: self.view.frame.size.width)
+            c.layer.shouldRasterize = true
+            c.layer.rasterizationScale = UIScreen.main.scale
+            cell = c
+        } else {
+            //Is mod log item
+            let c = tableView.dequeueReusableCell(withReuseIdentifier: "modlog", for: indexPath) as! ModlogCellView
+            c.setLogItem(logItem: (thing as! RModlogItem), parent: self, nav: self.navigationController, width: self.view.frame.size.width)
             c.layer.shouldRasterize = true
             c.layer.rasterizationScale = UIScreen.main.scale
             cell = c
@@ -344,7 +352,7 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
                 return CGSize(width: itemWidth, height: estimatedHeights[comment.id]!)
             } else if thing is RFriend {
                 return CGSize(width: itemWidth, height: 70)
-            } else {
+            } else if thing is RMessage {
                 let message = thing as! RMessage
                 if estimatedHeights[message.id] == nil {
                     let titleText = MessageCellView.getTitleText(message: message)
@@ -354,6 +362,16 @@ class ContentListingViewController: MediaViewController, UICollectionViewDelegat
                     estimatedHeights[message.id] = height + 20
                 }
                 return CGSize(width: itemWidth, height: estimatedHeights[message.id]!)
+            } else {
+                let logItem = thing as! RModlogItem
+                if estimatedHeights[logItem.id] == nil {
+                    let titleText = ModlogCellView.getTitleText(item: logItem)
+                    
+                    let height = TextDisplayStackView.estimateHeight(fontSize: 16, submission: false, width: itemWidth - 16, titleString: titleText, htmlString: logItem.targetTitle)
+                    
+                    estimatedHeights[logItem.id] = height + 20
+                }
+                return CGSize(width: itemWidth, height: estimatedHeights[logItem.id]!)
             }
         }
         return CGSize(width: itemWidth, height: 90)

--- a/Slide for Reddit/DragDownAlertMenu.swift
+++ b/Slide for Reddit/DragDownAlertMenu.swift
@@ -472,7 +472,7 @@ class DragDownAlertMenu: UIViewController, UITableViewDelegate, UITableViewDataS
         close.rightAnchor /==/ toReturn.rightAnchor - 16
         close.heightAnchor /==/ 30
         close.widthAnchor /==/ 30
-        close.addTapGestureRecognizer {
+        close.addTapGestureRecognizer { (_) in
             self.dismiss(animated: true, completion: nil)
         }
         close.isAccessibilityElement = true

--- a/Slide for Reddit/DragDownAlertMenu.swift
+++ b/Slide for Reddit/DragDownAlertMenu.swift
@@ -159,7 +159,8 @@ class BottomActionCell: UITableViewCell {
         icon.rightAnchor /==/ background.rightAnchor - 16
         icon.centerYAnchor /==/ background.centerYAnchor
         icon.heightAnchor /==/ 44
-        
+        icon.widthAnchor /==/ 44
+
         self.selectionStyle = .none
     }
     

--- a/Slide for Reddit/FriendCellView.swift
+++ b/Slide for Reddit/FriendCellView.swift
@@ -45,7 +45,7 @@ class FriendCellView: UICollectionViewCell, UIGestureRecognizerDelegate {
         self.contentView.backgroundColor = ColorUtil.theme.foregroundColor
         self.setupConstraints()
         
-        self.contentView.addTapGestureRecognizer {
+        self.contentView.addTapGestureRecognizer { (_) in
             let prof = ProfileViewController.init(name: self.friend?.name ?? "")
             VCPresenter.showVC(viewController: prof, popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
         }

--- a/Slide for Reddit/FullLinkCellView.swift
+++ b/Slide for Reddit/FullLinkCellView.swift
@@ -41,8 +41,7 @@ final class FullLinkCellView: LinkCellView {
                 awardContainerView.topAnchor /==/ title.bottomAnchor + ceight / 2
                 bannerImage.isHidden = false
                 // Image goes between title and buttons
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2
-                awardContainerView.bottomAnchor /<=/ bannerImage.topAnchor - ceight / 2
+                title.bottomAnchor /==/ bannerImage.topAnchor - ceight
 
                 bannerImage.horizontalAnchors /==/ innerView.horizontalAnchors + bannerPadding
                 bannerImage.bottomAnchor /==/ infoBox.topAnchor - ctwelve
@@ -69,8 +68,7 @@ final class FullLinkCellView: LinkCellView {
                 thumbImageContainer.bottomAnchor /<=/ infoBox.topAnchor - ceight
                 
                 // Thumbnail sizing
-                thumbImageContainer.topAnchor /==/ awardContainerView.bottomAnchor + ctwelve / 2
-                awardContainerView.topAnchor /==/ title.bottomAnchor + ctwelve / 2
+                thumbImageContainer.topAnchor /==/ title.bottomAnchor + ctwelve
                 thumbImageContainer.leftAnchor /==/ innerView.leftAnchor + ctwelve
                 infoContainer.heightAnchor /==/ CGFloat(75)
                 infoContainer.isHidden = false
@@ -82,8 +80,6 @@ final class FullLinkCellView: LinkCellView {
                 infoContainer.leftAnchor /==/ thumbImageContainer.rightAnchor + bannerPadding
                 infoContainer.verticalAnchors /==/ thumbImageContainer.verticalAnchors
                 infoContainer.rightAnchor /==/ innerView.rightAnchor - bannerPadding
-            } else {
-                awardContainerView.topAnchor /==/ title.bottomAnchor + ceight / 2
             }
         }
         layoutForContent()

--- a/Slide for Reddit/FullLinkCellView.swift
+++ b/Slide for Reddit/FullLinkCellView.swift
@@ -43,7 +43,7 @@ final class FullLinkCellView: LinkCellView {
                 title.bottomAnchor /==/ bannerImage.topAnchor - ceight
 
                 bannerImage.horizontalAnchors /==/ innerView.horizontalAnchors + bannerPadding
-                bannerImage.bottomAnchor /==/ infoBox.topAnchor - ctwelve
+                bannerImage.bottomAnchor /==/ infoBox.topAnchor - ctwelve / 2
                 if thumb {
                     infoContainer.isHidden = false
                 } else {

--- a/Slide for Reddit/FullLinkCellView.swift
+++ b/Slide for Reddit/FullLinkCellView.swift
@@ -32,7 +32,11 @@ final class FullLinkCellView: LinkCellView {
             textView.bottomAnchor /==/ infoBox.topAnchor - (ctwelve / 2)
             infoBox.bottomAnchor />=/ box.topAnchor - (ctwelve / 2)
             infoBox.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
-            textView.topAnchor /==/ title.bottomAnchor + ceight
+            if type == .SELF && big && !SettingValues.hideImageSelftext {
+                textView.topAnchor /==/ bannerImage.bottomAnchor + ceight
+            } else {
+                textView.topAnchor /==/ title.bottomAnchor + ceight
+            }
             textView.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
             title.topAnchor /==/ innerView.topAnchor + (ctwelve - 5)
             title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
@@ -43,7 +47,11 @@ final class FullLinkCellView: LinkCellView {
                 title.bottomAnchor /==/ bannerImage.topAnchor - ceight
 
                 bannerImage.horizontalAnchors /==/ innerView.horizontalAnchors + bannerPadding
-                bannerImage.bottomAnchor /==/ infoBox.topAnchor - ctwelve / 2
+                
+                if type != .SELF || SettingValues.hideImageSelftext {
+                    bannerImage.bottomAnchor /==/ infoBox.topAnchor - ctwelve / 2
+                }
+
                 if thumb {
                     infoContainer.isHidden = false
                 } else {

--- a/Slide for Reddit/FullLinkCellView.swift
+++ b/Slide for Reddit/FullLinkCellView.swift
@@ -32,13 +32,12 @@ final class FullLinkCellView: LinkCellView {
             textView.bottomAnchor /==/ infoBox.topAnchor - (ctwelve / 2)
             infoBox.bottomAnchor />=/ box.topAnchor - (ctwelve / 2)
             infoBox.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
-            textView.topAnchor /==/ awardContainerView.bottomAnchor + ceight / 2
+            textView.topAnchor /==/ title.bottomAnchor + ceight
             textView.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
             title.topAnchor /==/ innerView.topAnchor + (ctwelve - 5)
             title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
 
             if big {
-                awardContainerView.topAnchor /==/ title.bottomAnchor + ceight / 2
                 bannerImage.isHidden = false
                 // Image goes between title and buttons
                 title.bottomAnchor /==/ bannerImage.topAnchor - ceight

--- a/Slide for Reddit/GalleryCellView.swift
+++ b/Slide for Reddit/GalleryCellView.swift
@@ -37,10 +37,10 @@ class GalleryCellView: UITableViewCell {
         self.contentView.addSubview(commentsImage)
         self.contentView.addSubview(typeImage)
 
-        commentsImage.addTapGestureRecognizer {
+        commentsImage.addTapGestureRecognizer { (_) in
             VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.init(string: self.link!.permalink)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
         }
-        bannerImage.addTapGestureRecognizer {
+        bannerImage.addTapGestureRecognizer { (_) in
             parent.setLink(link: self.link!, shownURL: nil, lq: false, saveHistory: true, heroView: self.bannerImage, finalSize: self.bannerImage.image?.size, heroVC: parent, upvoteCallbackIn: nil)
         }
 

--- a/Slide for Reddit/GalleryLinkCellView.swift
+++ b/Slide for Reddit/GalleryLinkCellView.swift
@@ -68,7 +68,6 @@ final class GalleryLinkCellView: LinkCellView {
             }
 
         let attText = CachedTitle.getTitleAttributedString(link, force: false, gallery: true, full: full)
-        let bounds = self.estimateHeightSingle(full, np: np, attText: attText)
         title.attributedText = attText
     }
     

--- a/Slide for Reddit/GalleryLinkCellView.swift
+++ b/Slide for Reddit/GalleryLinkCellView.swift
@@ -24,8 +24,7 @@ final class GalleryLinkCellView: LinkCellView {
             // Image goes above title
             title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
             
-            title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2
-            awardContainerView.bottomAnchor /==/ box.topAnchor - ceight / 2
+            title.bottomAnchor /==/ box.topAnchor - ceight
 
             bannerImage.topAnchor /==/ innerView.topAnchor + bannerPadding
             bannerImage.bottomAnchor /==/ title.topAnchor - ceight

--- a/Slide for Reddit/GalleryLinkCellView.swift
+++ b/Slide for Reddit/GalleryLinkCellView.swift
@@ -69,14 +69,7 @@ final class GalleryLinkCellView: LinkCellView {
 
         let attText = CachedTitle.getTitleAttributedString(link, force: false, gallery: true, full: full)
         let bounds = self.estimateHeightSingle(full, np: np, attText: attText)
-        if oldBounds.width != bounds.textBoundingSize.width || oldBounds.height != bounds.textBoundingSize.height {
-            oldBounds = bounds.textBoundingSize
-            title.textLayout = bounds
-            title.textContainerInset = UIEdgeInsets(top: 3, left: 0, bottom: 0, right: 0)
-            title.preferredMaxLayoutWidth = bounds.textBoundingSize.width
-        }
         title.attributedText = attText
-        title.textVerticalAlignment = .top
     }
     
     override func refresh(np: Bool = false) {

--- a/Slide for Reddit/GalleryTableViewController.swift
+++ b/Slide for Reddit/GalleryTableViewController.swift
@@ -57,7 +57,7 @@ class GalleryTableViewController: MediaTableViewController {
             }
             exit.addSubview(image)
             image.edgeAnchors /==/ exit.edgeAnchors
-            exit.addTapGestureRecognizer {
+            exit.addTapGestureRecognizer { (_) in
                 self.exit.removeFromSuperview()
                 self.doExit()
             }

--- a/Slide for Reddit/IAPHandler.swift
+++ b/Slide for Reddit/IAPHandler.swift
@@ -93,7 +93,6 @@ extension IAPHandler: SKProductsRequestDelegate, SKPaymentTransactionObserver {
     }
     
     func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {
-        purchaseStatusBlock?(.restored)
     }
     
     // MARK: - IAP PAYMENT QUEUE
@@ -107,6 +106,7 @@ extension IAPHandler: SKProductsRequestDelegate, SKPaymentTransactionObserver {
                     print("Product Purchased")
                     purchaseStatusBlock?(.purchased)
                     SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
+                    break
                 case .failed:
                     print("Purchased Failed")
                     didFail = true
@@ -116,6 +116,7 @@ extension IAPHandler: SKProductsRequestDelegate, SKPaymentTransactionObserver {
                     print("Already Purchased")
                     purchaseStatusBlock?(.restored)
                     SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
+                    break
                 default:
                     break
                 }

--- a/Slide for Reddit/ImageMediaViewController.swift
+++ b/Slide for Reddit/ImageMediaViewController.swift
@@ -179,7 +179,7 @@ class ImageMediaViewController: EmbeddableMediaViewController {
             view.addGestureRecognizer(tap)
         }
         
-        imageView.addLongTapGestureRecognizer {
+        imageView.addLongTapGestureRecognizer { (_) in
             self.shareImage(sender: self.menuButton)
         }
 

--- a/Slide for Reddit/LinkCellImageCache.swift
+++ b/Slide for Reddit/LinkCellImageCache.swift
@@ -109,3 +109,12 @@ public class LinkCellImageCache {
     }
 
 }
+
+func optimizedImage(from image: UIImage) -> UIImage {
+    let imageSize: CGSize = image.size
+    UIGraphicsBeginImageContextWithOptions(imageSize, true, UIScreen.main.scale)
+    image.draw(in: CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.height))
+    let optimizedImage = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    return optimizedImage ?? UIImage()
+}

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -254,10 +254,8 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         
         self.thumbImageContainer = RoundedCornerView(radius: SettingValues.flatMode ? 0 : 10, cornerColor: ColorUtil.theme.foregroundColor).then {
             $0.accessibilityIdentifier = "Thumbnail Image Container"
+            $0.backgroundColor = ColorUtil.theme.foregroundColor
             $0.frame = CGRect(x: 0, y: 8, width: (SettingValues.largerThumbnail ? 75 : 50) - (SettingValues.postViewMode == .COMPACT ? 15 : 0), height: (SettingValues.largerThumbnail ? 75 : 50) - (SettingValues.postViewMode == .COMPACT ? 15 : 0))
-            if !SettingValues.flatMode {
-                $0.elevate(elevation: 2.0)
-            }
         }
         
         self.thumbImage = RoundedImageView(radius: SettingValues.flatMode ? 0 : 10, cornerColor: ColorUtil.theme.foregroundColor).then {
@@ -344,6 +342,10 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.contentInsetAdjustmentBehavior = .never
             $0.backgroundColor = ColorUtil.theme.foregroundColor
             $0.isUserInteractionEnabled = true
+            for subview in $0.subviews {
+                subview.isOpaque = true
+                subview.backgroundColor = ColorUtil.theme.foregroundColor
+            }
         }
         
         self.infoBox = UIStackView().then {
@@ -3055,11 +3057,14 @@ public extension UIImageView {
                             backView.accessibilityIgnoresInvertColors = true
                         }
                         backView.clipsToBounds = true
-
+                        backView.setCornerRadius()
+                        
                         self.superview?.bringSubviewToFront(self)
                     } else {
                         self.contentMode = .scaleAspectFill //Otherwise, fill view
-                    }
+                        if let round = self as? RoundedImageView {
+                            round.setCornerRadius()
+                        }                    }
                 } else if let round = self as? RoundedImageView {
                     round.setCornerRadius()
                 }

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -3042,8 +3042,9 @@ public extension UIImageView {
                 self.backgroundColor = oldBackgroundColor
                 
                 if SettingValues.postImageMode == .SHORT_IMAGE && isBannerView && self.superview != nil {
-                    if ((self.image?.size.height ?? 0) / (self.image?.size.width ?? 0)) > ( self.frame.size.height / self.frame.size.width) { //Aspect ratio of current image is less than
+                    if ((self.image?.size.height ?? 0) / (self.image?.size.width ?? 0)) > ( self.frame.size.height / self.frame.size.width) && ((self.image?.size.height ?? 0) > UIScreen.main.bounds.size.width / 2) { //Aspect ratio of current image is less than
                         self.contentMode = .scaleAspectFit
+                        
                         let backView = RoundedImageView(radius: SettingValues.flatMode ? 0 : 15, cornerColor: ColorUtil.theme.foregroundColor)
                         backView.image = self.image?.sd_blurredImage(withRadius: 15)
                         backView.contentMode = .scaleAspectFill
@@ -3057,15 +3058,15 @@ public extension UIImageView {
                             backView.accessibilityIgnoresInvertColors = true
                         }
                         backView.clipsToBounds = true
-                        backView.setCornerRadius()
+                        backView.setCornerRadius(rect: self.bounds)
                         
                         self.superview?.bringSubviewToFront(self)
                     } else {
                         self.contentMode = .scaleAspectFill //Otherwise, fill view
-                        if let round = self as? RoundedImageView {
-                            round.setCornerRadius()
-                        }                    }
-                } else if let round = self as? RoundedImageView {
+                    }
+                }
+                
+                if let round = self as? RoundedImageView {
                     round.setCornerRadius()
                 }
 
@@ -3603,8 +3604,10 @@ class RoundedImageView: UIImageView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setCornerRadius() {
-        let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: .allCorners, cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
+    func setCornerRadius(rect: CGRect? = nil) {
+        self.layer.mask = nil
+        self.layer.masksToBounds = false
+        let path = UIBezierPath(roundedRect: rect ?? self.bounds, byRoundingCorners: .allCorners, cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
         maskLayer?.removeFromSuperlayer()
         maskLayer = CAShapeLayer()
         maskLayer.frame = self.bounds

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -152,24 +152,24 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     var info: UILabel!
     var subicon: UIImageView!
     var textView: TextDisplayStackView!
-    var save: UIButton!
-    var menu: UIButton!
-    var upvote: UIButton!
-    var hide: UIButton!
-    var share: UIButton!
-    var edit: UIButton!
-    var reply: UIButton!
-    var downvote: UIButton!
-    var mod: UIButton!
-    var readLater: UIButton!
+    var save: UIImageView!
+    var menu: UIImageView!
+    var upvote: UIImageView!
+    var hide: UIImageView!
+    var share: UIImageView!
+    var edit: UIImageView!
+    var reply: UIImageView!
+    var downvote: UIImageView!
+    var mod: UIImageView!
+    var readLater: UIImageView!
     var commenticon: UIImageView!
     var submissionicon: UIImageView!
     weak var del: LinkCellViewDelegate?
     var taglabel: UILabel!
     var tagbody: UIView!
     var crosspost: UITableViewCell!
-    var sideUpvote: UIButton!
-    var sideDownvote: UIButton!
+    var sideUpvote: UIImageView!
+    var sideDownvote: UIImageView!
     var sideScore: UILabel!
     var innerView = UIView()
     var awardView: UIStackView!
@@ -229,6 +229,13 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     }
     
     func configureView() {
+        if (SettingValues.postViewMode == .CARD || SettingValues.postViewMode == .CENTER) && !full && !(self is GalleryLinkCellView) && !SettingValues.flatMode {
+            innerView = RoundedCornerView(radius: 15, cornerColor: ColorUtil.theme.foregroundColor)
+            self.innerView.backgroundColor = ColorUtil.theme.backgroundColor //The rounded corners code will take care of the foreground color
+        } else {
+            self.innerView.backgroundColor = ColorUtil.theme.foregroundColor
+        }
+
         if full {
             self.contentView.addSubview(innerView)
         } else {
@@ -247,12 +254,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             }
         }
         
-        self.thumbImage = UIImageView().then {
+        self.thumbImage = RoundedImageView(radius: SettingValues.flatMode ? 0 : 10, cornerColor: ColorUtil.theme.foregroundColor).then {
             $0.accessibilityIdentifier = "Thumbnail Image"
             $0.backgroundColor = UIColor.white
-            if !SettingValues.flatMode {
-                $0.layer.cornerRadius = 10
-            }
             if #available(iOS 11.0, *) {
                 $0.accessibilityIgnoresInvertColors = true
             }
@@ -297,23 +301,23 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         self.thumbText.heightAnchor /==/ 20
         self.thumbText.bottomAnchor /==/ self.thumbImage.bottomAnchor + 2
                 
-        self.bannerImage = UIImageView().then {
+        self.bannerImage = RoundedImageView(radius: SettingValues.flatMode ? 0 : 15, cornerColor: ColorUtil.theme.foregroundColor).then {
             $0.accessibilityIdentifier = "Banner Image"
             $0.contentMode = SettingValues.postImageMode == .SHORT_IMAGE && self is BannerLinkCellView ? .scaleAspectFit : .scaleAspectFill
-            if !SettingValues.flatMode {
-                $0.layer.cornerRadius = 15
-            }
             if #available(iOS 11.0, *) {
                 $0.accessibilityIgnoresInvertColors = true
             }
             $0.clipsToBounds = true
-            $0.backgroundColor = UIColor.white
+            $0.backgroundColor = ColorUtil.theme.backgroundColor
         }
         
         self.title = YYLabel(frame: CGRect(x: 75, y: 8, width: 0, height: 0)).then {
             $0.accessibilityIdentifier = "Post Title"
-            $0.isOpaque = false
             $0.numberOfLines = 0
+            $0.clipsToBounds = true
+            $0.layer.isOpaque = true
+            $0.isOpaque = true
+            $0.layer.backgroundColor = ColorUtil.theme.foregroundColor.cgColor
             $0.lineBreakMode = .byWordWrapping
             $0.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
             $0.backgroundColor = ColorUtil.theme.foregroundColor
@@ -338,93 +342,105 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.axis = .vertical
         }
         
-        self.hide = UIButton(type: .custom).then {
+        self.hide = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Hide Button"
-            $0.setImage(LinkCellImageCache.hide, for: .normal)
+            $0.image = LinkCellImageCache.hide
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.reply = UIButton(type: .custom).then {
+        self.reply = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Reply Button"
-            $0.setImage(LinkCellImageCache.reply, for: .normal)
+            $0.image = LinkCellImageCache.reply
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.edit = UIButton(type: .custom).then {
+        self.edit = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Edit Button"
-            $0.setImage(LinkCellImageCache.edit, for: .normal)
+            $0.image = LinkCellImageCache.edit
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.save = UIButton(type: .custom).then {
+        self.save = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Save Button"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.menu = UIButton(type: .custom).then {
+        self.menu = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Post menu"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.upvote = UIButton(type: .custom).then {
+        self.upvote = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Upvote Button"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.downvote = UIButton(type: .custom).then {
+        self.downvote = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Downvote Button"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.sideUpvote = UIButton(type: .custom).then {
+        self.sideUpvote = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Upvote Button"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.sideDownvote = UIButton(type: .custom).then {
+        self.sideDownvote = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Downvote Button"
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
-        self.mod = UIButton(type: .custom).then {
+        self.mod = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Mod Button"
-            $0.setImage(LinkCellImageCache.mod, for: .normal)
+            $0.image = LinkCellImageCache.mod
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
 
-        self.share = UIButton(type: .custom).then {
+        self.share = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Share Button"
             $0.contentMode = .center
-            $0.setImage(LinkCellImageCache.share, for: .normal)
-            $0.isOpaque = false
+            $0.image = LinkCellImageCache.share
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
 
-        self.readLater = UIButton(type: .custom).then {
+        self.readLater = UIImageView().then {
+            $0.contentMode = .scaleAspectFit
             $0.accessibilityIdentifier = "Read Later Button"
-            $0.setImage(LinkCellImageCache.readLater, for: .normal)
+            $0.image = LinkCellImageCache.readLater
             $0.contentMode = .center
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
@@ -432,7 +448,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Comment Count Icon"
             $0.image = LinkCellImageCache.commentsIcon
             $0.contentMode = .scaleAspectFit
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
@@ -440,7 +456,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Score Icon"
             $0.image = LinkCellImageCache.votesIcon
             $0.contentMode = .scaleAspectFit
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
@@ -448,7 +464,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Score Label"
             $0.numberOfLines = 1
             $0.textColor = ColorUtil.theme.fontColor
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
@@ -457,7 +473,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.numberOfLines = 1
             $0.textAlignment = .center
             $0.textColor = ColorUtil.theme.fontColor
-            $0.isOpaque = false
+            $0.isOpaque = true
         }
         
         self.comments = UILabel().then {
@@ -465,7 +481,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.numberOfLines = 1
             $0.font = FontGenerator.boldFontOfSize(size: 12, submission: true)
             $0.textColor = ColorUtil.theme.fontColor
-            $0.isOpaque = false
+            $0.isOpaque = true
             $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
@@ -619,21 +635,49 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         }
         
         if !addTouch {
-            save.addTarget(self, action: #selector(LinkCellView.save(sender:)), for: .touchUpInside)
-            upvote.addTarget(self, action: #selector(LinkCellView.upvote(sender:)), for: .touchUpInside)
-            if SettingValues.actionBarMode.isSide() {
-                sideUpvote.addTarget(self, action: #selector(LinkCellView.upvote(sender:)), for: .touchUpInside)
-                sideDownvote.addTarget(self, action: #selector(LinkCellView.downvote(sender:)), for: .touchUpInside)
+            save.addTapGestureRecognizer {
+                self.save()
             }
-            reply.addTarget(self, action: #selector(LinkCellView.reply(sender:)), for: .touchUpInside)
-            downvote.addTarget(self, action: #selector(LinkCellView.downvote(sender:)), for: .touchUpInside)
-            mod.addTarget(self, action: #selector(LinkCellView.mod(sender:)), for: .touchUpInside)
-            readLater.addTarget(self, action: #selector(readLater(sender:)), for: .touchUpInside)
-            edit.addTarget(self, action: #selector(LinkCellView.edit(sender:)), for: .touchUpInside)
-            hide.addTarget(self, action: #selector(LinkCellView.hide(sender:)), for: .touchUpInside)
-            share.addTarget(self, action: #selector(LinkCellView.share(sender:)), for: .touchUpInside)
-            sideUpvote.addTarget(self, action: #selector(LinkCellView.upvote(sender:)), for: .touchUpInside)
-            menu.addTarget(self, action: #selector(LinkCellView.more(sender:)), for: .touchUpInside)
+            upvote.addTapGestureRecognizer {
+                self.upvote()
+            }
+
+            if SettingValues.actionBarMode.isSide() {
+                sideUpvote.addTapGestureRecognizer {
+                    self.upvote()
+                }
+                sideDownvote.addTapGestureRecognizer {
+                    self.downvote()
+                }
+            }
+            
+            reply.addTapGestureRecognizer {
+                self.reply()
+            }
+            downvote.addTapGestureRecognizer {
+                self.downvote()
+            }
+            mod.addTapGestureRecognizer {
+                self.mod()
+            }
+            readLater.addTapGestureRecognizer {
+                self.readLater()
+            }
+            edit.addTapGestureRecognizer {
+                self.edit(sender: self.edit)
+            }
+            hide.addTapGestureRecognizer {
+                self.hide()
+            }
+            share.addTapGestureRecognizer {
+                self.share()
+            }
+            sideUpvote.addTapGestureRecognizer {
+                self.upvote()
+            }
+            menu.addTapGestureRecognizer {
+                self.more()
+            }
 
             addTouch(view: thumbImage, action: #selector(LinkCellView.openLink(sender:)))
             
@@ -1521,6 +1565,8 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                         flairView.sd_setImage(with: urlAsURL)
                         flairView.sizeAnchors == CGSize.square(size: 15)
                         awardView.addArrangedSubview(flairView)
+                        flairView.backgroundColor = ColorUtil.theme.foregroundColor
+                        flairView.isOpaque = true
                         flairView.addTapGestureRecognizer {
                             self.showAwardMenu()
                         }
@@ -1532,6 +1578,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 let label = UILabel().then {
                     $0.font = UIFont.boldSystemFont(ofSize: 10)
                     $0.text = "\(awardCount) Awards"
+                    $0.backgroundColor = ColorUtil.theme.foregroundColor
                     $0.textColor = ColorUtil.theme.fontColor
                 }
                 label.addTapGestureRecognizer {
@@ -1701,7 +1748,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 NSLog(error.localizedDescription)
             }
         }
-        
+            
         self.linkClicked = false
 
         self.full = self is FullLinkCellView
@@ -1715,7 +1762,10 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         self.loadedImage = nil
         lq = false
 
-        self.innerView.backgroundColor = ColorUtil.theme.foregroundColor
+        if let round = innerView as? RoundedCornerView, let shadow = round.shadowLayer {
+            shadow.removeFromSuperlayer()
+            round.shadowLayer = nil
+        }
         comments.textColor = ColorUtil.theme.navIconColor
         title.textColor = ColorUtil.theme.navIconColor
 
@@ -2615,26 +2665,26 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     func refresh(np: Bool = false) {
         let link = self.link!
 
-        upvote.setImage(LinkCellImageCache.upvote, for: .normal)
-        downvote.setImage(LinkCellImageCache.downvote, for: .normal)
-        sideUpvote.setImage(LinkCellImageCache.upvoteSmall, for: .normal)
-        sideDownvote.setImage(LinkCellImageCache.downvoteSmall, for: .normal)
-        share.setImage(LinkCellImageCache.share, for: .normal)
-        menu.setImage(LinkCellImageCache.menu, for: .normal)
+        upvote.image = LinkCellImageCache.upvote
+        downvote.image = LinkCellImageCache.downvote
+        sideUpvote.image = LinkCellImageCache.upvoteSmall
+        sideDownvote.image = LinkCellImageCache.downvoteSmall
+        share.image = LinkCellImageCache.share
+        menu.image = LinkCellImageCache.menu
 
-        save.setImage(ActionStates.isSaved(s: link) ? LinkCellImageCache.saveTinted : LinkCellImageCache.save, for: .normal)
-        mod.setImage(link.reports.isEmpty ? LinkCellImageCache.mod : LinkCellImageCache.modTinted, for: .normal)
-        readLater.setImage(ReadLater.isReadLater(id: link.getId()) ? LinkCellImageCache.readLaterTinted : LinkCellImageCache.readLater, for: .normal)
-        
+        save.image = ActionStates.isSaved(s: link) ? LinkCellImageCache.saveTinted : LinkCellImageCache.save
+        mod.image = link.reports.isEmpty ? LinkCellImageCache.mod : LinkCellImageCache.modTinted
+        readLater.image = ReadLater.isReadLater(id: link.getId()) ? LinkCellImageCache.readLaterTinted : LinkCellImageCache.readLater
+
         var attrs: [NSAttributedString.Key: Any] = [:]
         switch ActionStates.getVoteDirection(s: link) {
         case .down:
-            downvote.setImage(LinkCellImageCache.downvoteTinted, for: .normal)
-            sideDownvote.setImage(LinkCellImageCache.downvoteTintedSmall, for: .normal)
+            downvote.image = LinkCellImageCache.downvoteTinted
+            sideDownvote.image = LinkCellImageCache.downvoteTintedSmall
             attrs = ([NSAttributedString.Key.foregroundColor: ColorUtil.downvoteColor, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
         case .up:
-            upvote.setImage(LinkCellImageCache.upvoteTinted, for: .normal)
-            sideUpvote.setImage(LinkCellImageCache.upvoteTintedSmall, for: .normal)
+            upvote.image = LinkCellImageCache.upvoteTinted
+            sideUpvote.image = LinkCellImageCache.upvoteTintedSmall
             attrs = ([NSAttributedString.Key.foregroundColor: ColorUtil.upvoteColor, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
         default:
             attrs = ([NSAttributedString.Key.foregroundColor: ColorUtil.theme.navIconColor, NSAttributedString.Key.font: FontGenerator.boldFontOfSize(size: 12, submission: true)])
@@ -2832,11 +2882,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         }
         
         super.layoutSubviews()
-
-        if (SettingValues.postViewMode == .CARD || SettingValues.postViewMode == .CENTER) && !full && !(self is GalleryLinkCellView) && !SettingValues.flatMode && !setElevation {
-            setElevation = true
-            self.innerView.elevate(elevation: 2)
-        }
     }
     
     var registered: Bool = false
@@ -3254,6 +3299,7 @@ public extension UIImageView {
                         self.contentMode = .scaleAspectFit
                         let backView = UIImageView(image: self.image?.sd_blurredImage(withRadius: 15))
                         backView.contentMode = .scaleAspectFill
+                        backView.backgroundColor = ColorUtil.theme.backgroundColor
                         backView.tag = 2000 //Need to find a solution to this, tags are bad
                         self.superview?.addSubview(backView)
                         backView.edgeAnchors /==/ self.edgeAnchors
@@ -3723,3 +3769,63 @@ extension LinkCellView: UIContextMenuInteractionDelegate {
     }
 }
 
+class RoundedCornerView: UIView {
+    var cornerRadius = 0 as CGFloat
+    var cornerColor: UIColor
+    init(radius: CGFloat, cornerColor: UIColor) {
+        self.cornerRadius = radius
+        self.cornerColor = cornerColor
+        super.init(frame: CGRect.zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func draw(_ rect: CGRect) {
+        let borderPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius)
+        cornerColor.set()
+        borderPath.fill()
+    }
+    
+    public var shadowLayer: CAShapeLayer!
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        if shadowLayer == nil {
+            shadowLayer = CAShapeLayer()
+            shadowLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath
+            shadowLayer.fillColor = cornerColor.cgColor
+
+            shadowLayer.shadowPath = shadowLayer.path
+            
+            shadowLayer.shadowColor = UIColor.black.cgColor
+            shadowLayer.shadowOffset = CGSize(width: 0, height: 2)
+            shadowLayer.shadowRadius = CGFloat(2)
+            shadowLayer.shadowOpacity = 0.24
+
+            layer.insertSublayer(shadowLayer, at: 0)
+        }
+    }
+}
+
+class RoundedImageView: UIImageView {
+    var cornerRadius = 0 as CGFloat
+    var cornerColor: UIColor
+    init(radius: CGFloat, cornerColor: UIColor) {
+        self.cornerRadius = radius
+        self.cornerColor = cornerColor
+        super.init(frame: CGRect.zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func draw(_ rect: CGRect) {
+        let borderPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius)
+        cornerColor.set()
+        borderPath.fill()
+    }
+}

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1437,6 +1437,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         
         let finalTitle = CachedTitle.getTitleAttributedString(link, force: force, gallery: false, full: full)
         title.attributedText = finalTitle
+        print(finalTitle.string)
         
         title.isScrollEnabled = false
         title.sizeToFit()
@@ -2780,16 +2781,14 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
             } else if big {
                 if SettingValues.postViewMode == .CENTER || full {
-                    innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 16) //between label
-                    innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between banner and box
+                    innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between label
+                    innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between banner and box
                 } else {
                     innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between banner and label
                     innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between label and box
                 }
                 innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
             } else {
-                innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8)
-                innerPadding += 5 //between label and body
                 innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between body and box
                 innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
             }
@@ -2883,7 +2882,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     
     @objc func openLink(sender: UITapGestureRecognizer? = nil) {
         if let link = link {
-            if type == .SELF {
+            if type == .SELF && full {
                 if let image = URL(string: link.bannerUrl) {
                     self.parentViewController?.doShow(url: image, heroView: nil, finalSize: nil, heroVC: nil, link: link)
                     return

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1437,16 +1437,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         
         let finalTitle = CachedTitle.getTitleAttributedString(link, force: force, gallery: false, full: full)
         title.attributedText = finalTitle
-        print(finalTitle.string)
         
         title.isScrollEnabled = false
         title.sizeToFit()
-
-        /*title.removeConstraints(titleAttrs)
-        titleAttrs = batch {
-            title.heightAnchor /==/ bounds.textBoundingSize.height
-        }*/
-        //title.exclusionPaths = [UIBezierPath(rect: CGRect(x: 0, y: 0, width: 32, height: 5))]
     }
             
     @objc func doDTap(_ sender: AnyObject) {

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -9,8 +9,9 @@
 import Anchorage
 import AudioToolbox
 import AVKit
-import Photos
 import MaterialComponents
+import Photos
+import Proton
 import reddift
 import RLBAlertsPickers
 import SafariServices
@@ -311,15 +312,24 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.backgroundColor = ColorUtil.theme.backgroundColor
         }
         
-        self.title = UITextView(frame: CGRect(x: 75, y: 8, width: 0, height: 0)).then {
+        let layout = BadgeLayoutManager()
+        let storage = NSTextStorage()
+        storage.addLayoutManager(layout)
+        let initialSize = CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        let container = NSTextContainer(size: initialSize)
+        container.widthTracksTextView = true
+        layout.addTextContainer(container)
+
+        self.title = UITextView(frame: .zero, textContainer: container).then {
             $0.accessibilityIdentifier = "Post Title"
-            $0.clipsToBounds = true
+            $0.clipsToBounds = false
+            $0.textContainer.lineFragmentPadding = 0
+            $0.textContainerInset = .zero
             $0.showsHorizontalScrollIndicator = false
             $0.showsVerticalScrollIndicator = false
             $0.layer.isOpaque = true
             $0.isOpaque = true
             $0.layoutManager.allowsNonContiguousLayout = false
-            $0.textContainer.lineFragmentPadding = 0
             $0.isScrollEnabled = false
             $0.layer.backgroundColor = ColorUtil.theme.foregroundColor.cgColor
             $0.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
@@ -341,7 +351,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.hide
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.reply = UIImageView().then {
@@ -350,7 +359,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.reply
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.edit = UIImageView().then {
@@ -359,7 +367,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.edit
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.save = UIImageView().then {
@@ -367,7 +374,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Save Button"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.menu = UIImageView().then {
@@ -375,7 +381,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Post menu"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.upvote = UIImageView().then {
@@ -383,7 +388,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Upvote Button"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.downvote = UIImageView().then {
@@ -391,7 +395,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Downvote Button"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.sideUpvote = UIImageView().then {
@@ -399,7 +402,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Upvote Button"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.sideDownvote = UIImageView().then {
@@ -407,7 +409,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.accessibilityIdentifier = "Downvote Button"
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.mod = UIImageView().then {
@@ -416,7 +417,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.mod
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
 
         self.share = UIImageView().then {
@@ -425,7 +425,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.contentMode = .center
             $0.image = LinkCellImageCache.share
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
 
         self.readLater = UIImageView().then {
@@ -434,7 +433,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.readLater
             $0.contentMode = .center
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.commenticon = UIImageView(frame: CGRect(x: 0, y: 0, width: 10, height: 10)).then {
@@ -442,7 +440,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.commentsIcon
             $0.contentMode = .scaleAspectFit
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.submissionicon = UIImageView(frame: CGRect(x: 0, y: 0, width: 10, height: 10)).then {
@@ -450,7 +447,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.image = LinkCellImageCache.votesIcon
             $0.contentMode = .scaleAspectFit
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.score = UILabel().then {
@@ -458,7 +454,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.numberOfLines = 1
             $0.textColor = ColorUtil.theme.fontColor
             $0.isOpaque = true
-            $0.backgroundColor = ColorUtil.theme.foregroundColor
         }
         
         self.sideScore = UILabel().then {
@@ -524,11 +519,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         } else {
             innerView.addSubviews(bannerImage, thumbImageContainer, title, awardContainerView, subicon, infoContainer, tagbody)
         }
-        
-        subicon.sizeAnchors /==/ CGSize.square(size: 24)
-        subicon.leftAnchor /==/ title.leftAnchor
-        subicon.topAnchor /==/ title.topAnchor
-        
+                
         self.awardContainerView.addSubview(awardView)
         
         if self is AutoplayBannerLinkCellView || self is FullLinkCellView || self is GalleryLinkCellView {
@@ -1449,11 +1440,13 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         guard let link = self.link else {
             return
         }
-
-        let finalTitle = CachedTitle.getTitleAttributedString(link, force: force, gallery: false, full: full, textView: title)
+        
+        let finalTitle = CachedTitle.getTitleAttributedString(link, force: force, gallery: false, full: full)
         title.attributedText = finalTitle
-        title.layoutIfNeeded()
+        
+        title.isScrollEnabled = false
         title.sizeToFit()
+
         /*title.removeConstraints(titleAttrs)
         titleAttrs = batch {
             title.heightAnchor /==/ bounds.textBoundingSize.height
@@ -3728,12 +3721,39 @@ class RoundedImageView: UIImageView {
 }
 
 extension NSAttributedString {
-
     func height(containerWidth: CGFloat) -> CGFloat {
+        let size = CGSize(width: containerWidth, height: .infinity)
+        let boundingBox = self.boundingRect(
+            with: size,
+            options: [.usesLineFragmentOrigin, .usesFontLeading, .usesDeviceMetrics],
+            context: nil
+        )
+        return boundingBox.height
+    }
+    func height2(containerWidth: CGFloat) -> CGFloat {
+        let textStorage = NSTextStorage(attributedString: self)
+        let size = CGSize(width: containerWidth, height: CGFloat.greatestFiniteMagnitude)
+        let boundingRect = CGRect(origin: .zero, size: size)
 
-        let rect = self.boundingRect(with: CGSize.init(width: containerWidth, height: CGFloat.greatestFiniteMagnitude),
-                                     options: [.usesLineFragmentOrigin, .usesFontLeading],
-                                     context: nil)
-        return ceil(rect.size.height)
+        let textContainer = NSTextContainer(size: size)
+        textContainer.lineFragmentPadding = 0
+
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(textContainer)
+
+        textStorage.addLayoutManager(layoutManager)
+
+        self.enumerateAttribute(.attachment, in: NSRange(location: 0, length: self.length), options: []) { (value, range, _) in
+            if let attachment = value as? NSTextAttachment {
+                layoutManager.setAttachmentSize(CGSize.square(size: 24), forGlyphRange: range)
+                layoutManager.setNeedsLayout(forAttachment: attachment)
+                layoutManager.setNeedsDisplay(forAttachment: attachment)
+            }
+        }
+        layoutManager.glyphRange(forBoundingRect: boundingRect, in: textContainer)
+
+        let rect = layoutManager.usedRect(for: textContainer)
+
+        return rect.integral.size.height
     }
 }

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -2802,7 +2802,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             } else {
                 estimatedUsableWidth -= (24) //12 padding on either side
                 if thumb {
-                    fullHeightExtras += 45 + 12 + 12
+                    fullHeightExtras += 45 + 12
                 } else {
                     fullHeightExtras += imageHeight
                 }

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1654,7 +1654,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         } else if big && ((!full && SettingValues.postImageMode == .CROPPED_IMAGE) || (full && !SettingValues.commentFullScreen)) && !overrideFull {
             submissionHeight = test ? 150 : 200
         } else if big {
-            let h = getHeightFromAspectRatio(imageHeight: submissionHeight, imageWidth: CGFloat(submission.width), viewWidth: (parentWidth == 0 ? (innerView.frame.size.width == 0 ? CGFloat(submission.width) : innerView.frame.size.width) : parentWidth) - (full ? 10 : 0))
+            let h = getHeightFromAspectRatio(imageHeight: submissionHeight, imageWidth: CGFloat(submission.width), viewWidth: (parentWidth == 0 ? (innerView.frame.size.width == 0 ? CGFloat(submission.width) : innerView.frame.size.width) : parentWidth) - (full ? 10 : 0) - ((SettingValues.postViewMode != .CARD && SettingValues.postViewMode != .CENTER && !(self is GalleryLinkCellView)) ? CGFloat(10) : CGFloat(0)))
             if (!full && SettingValues.postImageMode == .SHORT_IMAGE && !(self is AutoplayBannerLinkCellView)) && !overrideFull {
                 submissionHeight = test ? 200 : (h > halfScreen ? halfScreen : h)
             } else {
@@ -1957,7 +1957,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             
             popup.numberOfLines = 2
             
-            outer.elevate(elevation: 2)
+            if !SettingValues.reduceElevation {
+                outer.elevate(elevation: 2)
+            }
             outer.layer.cornerRadius = 5
             outer.clipsToBounds = true
             
@@ -2624,7 +2626,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 
                 popup.numberOfLines = 2
                 
-                outer.elevate(elevation: 2)
+                if !SettingValues.reduceElevation {
+                    outer.elevate(elevation: 2)
+                }
                 outer.layer.cornerRadius = 5
                 outer.clipsToBounds = true
                 
@@ -2678,7 +2682,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 
                 popup.numberOfLines = 2
                 
-                outer.elevate(elevation: 2)
+                if !SettingValues.reduceElevation {
+                    outer.elevate(elevation: 2)
+                }
                 outer.layer.cornerRadius = 5
                 outer.clipsToBounds = true
                 
@@ -3549,7 +3555,7 @@ class RoundedCornerView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        if shadowLayer == nil {
+        if shadowLayer == nil && !SettingValues.reduceElevation {
             shadowLayer = CAShapeLayer()
             shadowLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath
             shadowLayer.fillColor = cornerColor.cgColor

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1451,18 +1451,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         }
 
         let finalTitle = CachedTitle.getTitleAttributedString(link, force: force, gallery: false, full: full, textView: title)
-        subicon.isHidden = true
-        
-        if (link.subreddit_icon != "" || Subscriptions.icon(for: link.subreddit) != nil) && SettingValues.subredditIcons && !full {
-            if Subscriptions.icon(for: link.subreddit) == nil {
-                Subscriptions.subIcons[link.subreddit.lowercased()] = link.subreddit_icon.unescapeHTML
-            }
-            if let urlAsURL = URL(string: Subscriptions.icon(for: link.subreddit.lowercased())!.unescapeHTML) {
-                subicon.isHidden = false
-                subicon.sd_setImage(with: urlAsURL, placeholderImage: UIImage(), options: [], context: nil)
-                subicon.backgroundColor = ColorUtil.getColorForSub(sub: link.subreddit)
-            }
-        }
         title.attributedText = finalTitle
         title.layoutIfNeeded()
         title.sizeToFit()
@@ -2962,98 +2950,12 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 estimatedUsableWidth = 100
             }
             
-            let size = CGSize(width: estimatedUsableWidth, height: CGFloat.greatestFiniteMagnitude)
-            let layout = title.attributedText!.boundingRect(with: size, options: [], context: nil)
-            let textSize = layout.size
+            let titleHeight = title.attributedText!.height(containerWidth: estimatedUsableWidth)
             
-            let totalHeight = paddingTop + paddingBottom + (full ? ceil(textSize.height) : (thumb && !full ? max((!full && SettingValues.actionBarMode.isSide() ? max(ceil(textSize.height), 72) : ceil(textSize.height)), imageHeight) : (!full && SettingValues.actionBarMode.isSide() ? max(ceil(textSize.height), 72) : ceil(textSize.height)) + imageHeight)) + innerPadding + actionbar + textHeight + fullHeightExtras + CGFloat(5) + CGFloat((link?.gilded ?? false) && !SettingValues.hideAwards ? 23 : 0)
+            let totalHeight = paddingTop + paddingBottom + (full ? ceil(titleHeight) : (thumb && !full ? max((!full && SettingValues.actionBarMode.isSide() ? max(ceil(titleHeight), 72) : ceil(titleHeight)), imageHeight) : (!full && SettingValues.actionBarMode.isSide() ? max(ceil(titleHeight), 72) : ceil(titleHeight)) + imageHeight)) + innerPadding + actionbar + textHeight + fullHeightExtras + CGFloat(5) + CGFloat((link?.gilded ?? false) && !SettingValues.hideAwards ? 23 : 0)
             estimatedHeight = totalHeight
         }
         return estimatedHeight
-    }
-    
-    func estimateHeightSingle(_ full: Bool, np: Bool, attText: NSAttributedString) -> YYTextLayout {
-        var paddingLeft = CGFloat(0)
-        var paddingRight = CGFloat(0)
-        var innerPadding = CGFloat(0)
-        if (SettingValues.postViewMode == .CARD || SettingValues.postViewMode == .CENTER) && !full && !(self is GalleryLinkCellView) {
-            paddingLeft = 5
-            paddingRight = 5
-        }
-        var imageHeight = big && !thumb ? CGFloat(submissionHeight) : CGFloat(0)
-        let thumbheight = (full || SettingValues.largerThumbnail ? CGFloat(75) : CGFloat(50)) - (!full && SettingValues.postViewMode == .COMPACT ? 15 : 0)
-        
-        if thumb {
-            imageHeight = thumbheight
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between top and thumbnail
-            innerPadding += 18 - (SettingValues.postViewMode == .COMPACT && !full ? 4 : 0) //between label and bottom box
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
-        } else if big {
-            if SettingValues.postViewMode == .CENTER || full {
-                innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 16) //between label
-                innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between banner and box
-            } else {
-                innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between banner and label
-                innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between label and box
-            }
-            
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
-        } else {
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8)
-            innerPadding += 5 //between label and body
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between body and box
-            innerPadding += (SettingValues.postViewMode == .COMPACT && !full ? 4 : 8) //between box and end
-        }
-        
-        var estimatedUsableWidth = aspectWidth - paddingLeft - paddingRight
-        var fullHeightExtras = CGFloat(0)
-        
-        if !full {
-            if thumb {
-                estimatedUsableWidth -= thumbheight //is the same as the width
-                estimatedUsableWidth -= (SettingValues.postViewMode == .COMPACT && !full ? 16 : 24) //between edge and thumb
-                estimatedUsableWidth -= (SettingValues.postViewMode == .COMPACT && !full ? 8 : 12) //between thumb and label
-            } else {
-                estimatedUsableWidth -= (SettingValues.postViewMode == .COMPACT && !full ? 16 : 24) //12 padding on either side
-            }
-        } else {
-            fullHeightExtras += 12
-            estimatedUsableWidth -= (35) //12 padding on either side
-            if thumb {
-                fullHeightExtras += 45 + 12 + 12
-            } else {
-                fullHeightExtras += imageHeight
-            }
-            
-            if link!.archived || link!.locked || np {
-                fullHeightExtras += 56
-            }
-            
-            fullHeightExtras += 8
-            
-            if link!.isCrosspost {
-                fullHeightExtras += 56
-            }
-        }
-        
-        if SettingValues.actionBarMode.isSide() && !full {
-            estimatedUsableWidth -= 40
-            estimatedUsableWidth -= (SettingValues.postViewMode == .COMPACT ? 8 : 16) //buttons horizontal margins
-            if thumb {
-                estimatedUsableWidth += (SettingValues.postViewMode == .COMPACT ? 16 : 24) //between edge and thumb no longer exists
-                estimatedUsableWidth -= (SettingValues.postViewMode == .COMPACT ? 4 : 8) //buttons buttons and thumb
-            }
-        }
-        
-        //Temporary fix to iOS 14 crash
-        //TODO fix
-        if estimatedUsableWidth < 0 {
-            estimatedUsableWidth = 100
-        }
-        
-        let size = CGSize(width: estimatedUsableWidth, height: CGFloat.greatestFiniteMagnitude)
-        let layout = YYTextLayout(containerSize: size, text: attText)!
-        return layout
     }
     
     // TODO: - this
@@ -3822,5 +3724,16 @@ class RoundedImageView: UIImageView {
         maskLayer.path = path.cgPath
         self.layer.mask = maskLayer
         self.layer.masksToBounds = true
+    }
+}
+
+extension NSAttributedString {
+
+    func height(containerWidth: CGFloat) -> CGFloat {
+
+        let rect = self.boundingRect(with: CGSize.init(width: containerWidth, height: CGFloat.greatestFiniteMagnitude),
+                                     options: [.usesLineFragmentOrigin, .usesFontLeading],
+                                     context: nil)
+        return ceil(rect.size.height)
     }
 }

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -710,7 +710,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 self.innerView.addGestureRecognizer(longPress!)
             }
             
-            self.awardContainerView.addTapGestureRecognizer {
+            self.awardView.addTapGestureRecognizer {
                 self.showAwardMenu()
             }
             addTouch = true
@@ -745,8 +745,8 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         for raw in sortedValues {
             if let award = raw as? [String] {
                 coinTotal += Int(award[4]) ?? 0
-                alertController.addView(title: "\(award[0]) x\(award[2])", icon_url: award[1], action: {() in
-                    let alertController = DragDownAlertMenu(title: award[0], subtitle: award[3], icon: award[1])
+                alertController.addView(title: "\(award[0]) x\(award[2])", icon_url: award[5], action: {() in
+                    let alertController = DragDownAlertMenu(title: award[0], subtitle: award[3], icon: award[5])
                     alertController.modalPresentationStyle = .overCurrentContext
                     if let window = UIApplication.shared.keyWindow, let modalVC = window.rootViewController?.presentedViewController {
                         if let presented = modalVC.presentedViewController {

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1720,6 +1720,8 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         
         if thumb && type == .SELF {
             thumb = false
+        } else if type == .SELF && !SettingValues.hideImageSelftext && submissionHeight > 0 {
+            big = true
         }
         
         if (thumb || big) && submission.spoiler {
@@ -1846,6 +1848,10 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 }
                 
                 submissionHeight = test ? 150 : 200
+            }
+            
+            if type == .SELF && !SettingValues.hideImageSelftext && submissionHeight > 200 {
+                 submissionHeight = 200
             }
             bannerImage.isUserInteractionEnabled = true
 
@@ -2877,6 +2883,12 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     
     @objc func openLink(sender: UITapGestureRecognizer? = nil) {
         if let link = link {
+            if type == .SELF {
+                if let image = URL(string: link.bannerUrl) {
+                    self.parentViewController?.doShow(url: image, heroView: nil, finalSize: nil, heroVC: nil, link: link)
+                    return
+                }
+            }
             (parentViewController)?.setLink(link: link, shownURL: loadedImage, lq: lq, saveHistory: true, heroView: big ? bannerImage : thumbImage, finalSize: CGSize(width: link.width, height: link.height), heroVC: parentViewController, upvoteCallbackIn: {[weak self] in
                 if let strongSelf = self {
                     strongSelf.upvote()

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -41,10 +41,12 @@ enum CurrentType {
 class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UIGestureRecognizerDelegate, TextDisplayStackViewDelegate {
     
     func linkTapped(url: URL, text: String) {
-        if !full {
+        linkClicked = true
+        if url.absoluteString == CachedTitle.AWARD_KEY {
+            showAwardMenu()
             return
         }
-        linkClicked = true
+        
         if !text.isEmpty {
             self.parentViewController?.showSpoiler(text)
         } else {
@@ -55,6 +57,11 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
     func linkLongTapped(url: URL) {
         longBlocking = true
         
+        if url.absoluteString == CachedTitle.AWARD_KEY {
+            showAwardMenu()
+            return
+        }
+
         let alertController = DragDownAlertMenu(title: "Link options", subtitle: url.absoluteString, icon: url.absoluteString)
         
         alertController.addAction(title: "Share URL", icon: UIImage(sfString: SFSymbol.squareAndArrowUp, overrideString: "share")!.menuIcon()) {
@@ -318,7 +325,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         container.widthTracksTextView = true
         layout.addTextContainer(container)
 
-        self.title = UITextView(frame: .zero, textContainer: container).then {
+        self.title = TitleUITextView(delegate: self, textContainer: container).then {
             $0.accessibilityIdentifier = "Post Title"
             $0.clipsToBounds = false
             $0.textContainer.lineFragmentPadding = 0
@@ -327,6 +334,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.showsVerticalScrollIndicator = false
             $0.layer.isOpaque = true
             $0.isOpaque = true
+            $0.isSelectable = false
             $0.layoutManager.allowsNonContiguousLayout = false
             $0.isScrollEnabled = false
             $0.layer.backgroundColor = ColorUtil.theme.foregroundColor.cgColor
@@ -335,7 +343,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             $0.contentInset = .zero
             $0.contentInsetAdjustmentBehavior = .never
             $0.backgroundColor = ColorUtil.theme.foregroundColor
-            $0.isUserInteractionEnabled = false
+            $0.isUserInteractionEnabled = true
         }
         
         self.infoBox = UIStackView().then {
@@ -610,47 +618,47 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         }
         
         if !addTouch {
-            save.addTapGestureRecognizer {
+            save.addTapGestureRecognizer { (_) in
                 self.save()
             }
-            upvote.addTapGestureRecognizer {
+            upvote.addTapGestureRecognizer { (_) in
                 self.upvote()
             }
 
             if SettingValues.actionBarMode.isSide() {
-                sideUpvote.addTapGestureRecognizer {
+                sideUpvote.addTapGestureRecognizer { (_) in
                     self.upvote()
                 }
-                sideDownvote.addTapGestureRecognizer {
+                sideDownvote.addTapGestureRecognizer { (_) in
                     self.downvote()
                 }
             }
             
-            reply.addTapGestureRecognizer {
+            reply.addTapGestureRecognizer { (_) in
                 self.reply()
             }
-            downvote.addTapGestureRecognizer {
+            downvote.addTapGestureRecognizer { (_) in
                 self.downvote()
             }
-            mod.addTapGestureRecognizer {
+            mod.addTapGestureRecognizer { (_) in
                 self.mod()
             }
-            readLater.addTapGestureRecognizer {
+            readLater.addTapGestureRecognizer { (_) in
                 self.readLater()
             }
-            edit.addTapGestureRecognizer {
+            edit.addTapGestureRecognizer { (_) in
                 self.edit(sender: self.edit)
             }
-            hide.addTapGestureRecognizer {
+            hide.addTapGestureRecognizer { (_) in
                 self.hide()
             }
-            share.addTapGestureRecognizer {
+            share.addTapGestureRecognizer { (_) in
                 self.share()
             }
-            sideUpvote.addTapGestureRecognizer {
+            sideUpvote.addTapGestureRecognizer { (_) in
                 self.upvote()
             }
-            menu.addTapGestureRecognizer {
+            menu.addTapGestureRecognizer { (_) in
                 self.more()
             }
 
@@ -1989,7 +1997,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             endString.append(authorString)
             boldString.append(endString)
             
-            outer.addTapGestureRecognizer {
+            outer.addTapGestureRecognizer { (_) in
                 VCPresenter.openRedditLink(submission.crosspostPermalink, self.parentViewController?.navigationController, self.parentViewController)
             }
             popup.attributedText = boldString
@@ -2635,7 +2643,7 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 outer.horizontalAnchors /==/ infoBox.horizontalAnchors
                 outer.heightAnchor /==/ 48
                 
-                outer.addTapGestureRecognizer {
+                outer.addTapGestureRecognizer { (_) in
                     let shareItems: Array = [link.url]
                     let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: shareItems as [Any], applicationActivities: nil)
                     if let presenter = activityViewController.popoverPresentationController {

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1780,6 +1780,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 thumbText.isHidden = false
                 thumbText.text = type.rawValue.uppercased()
                 thumbImage.loadImageWithPulsingAnimation(atUrl: URL(string: submission.smallPreview == "" ? submission.thumbnailUrl : submission.smallPreview), withPlaceHolderImage: LinkCellImageCache.web, isBannerView: false)
+                if let round = thumbImage as? RoundedImageView {
+                    round.setCornerRadius()
+                }
             }
             
         } else {
@@ -1863,6 +1866,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             lq = shouldShowLq
             if submission.bannerUrl == "" || submission.width == 0 {
                 bannerImage.image = LinkCellImageCache.webBig
+                if let round = bannerImage as? RoundedImageView {
+                    round.setCornerRadius()
+                }
             } else {
                 let bannerImageUrl = URL(string: shouldShowLq ? submission.lqUrl : submission.bannerUrl)
                 loadedImage = bannerImageUrl

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -1753,12 +1753,18 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
             } else {
                 thumbImage.image = LinkCellImageCache.web
             }
+            if let round = thumbImage as? RoundedImageView {
+                round.setCornerRadius()
+            }
         } else if thumb && !big {
             thumbText.isHidden = true
             if submission.nsfw && (!SettingValues.nsfwPreviews || SettingValues.hideNSFWCollection && Subscriptions.isCollection(baseSub)) {
                 thumbImage.image = SettingValues.thumbTag ? LinkCellImageCache.nsfwUp : LinkCellImageCache.nsfw
                 thumbText.isHidden = false
                 thumbText.text = type.rawValue.uppercased()
+                if let round = thumbImage as? RoundedImageView {
+                    round.setCornerRadius()
+                }
             } else if submission.thumbnailUrl == "web" || submission.thumbnailUrl.isEmpty || submission.spoiler {
                 if submission.spoiler {
                     thumbImage.image = LinkCellImageCache.spoiler
@@ -1767,11 +1773,15 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 } else {
                     thumbImage.image = LinkCellImageCache.web
                 }
+                if let round = thumbImage as? RoundedImageView {
+                    round.setCornerRadius()
+                }
             } else {
                 thumbText.isHidden = false
                 thumbText.text = type.rawValue.uppercased()
                 thumbImage.loadImageWithPulsingAnimation(atUrl: URL(string: submission.smallPreview == "" ? submission.thumbnailUrl : submission.smallPreview), withPlaceHolderImage: LinkCellImageCache.web, isBannerView: false)
             }
+            
         } else {
             thumbImage.image = nil
             thumbText.isHidden = true
@@ -2218,9 +2228,12 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
         }
 
         strongSelf.sound.addTarget(strongSelf, action: #selector(strongSelf.unmute), for: .touchUpInside)
-        strongSelf.updater = CADisplayLink(target: strongSelf, selector: #selector(strongSelf.displayLinkDidUpdate))
-        strongSelf.updater?.add(to: .current, forMode: RunLoop.Mode.common)
-        strongSelf.updater?.isPaused = false
+        
+        if strongSelf.updater == nil {
+            strongSelf.updater = CADisplayLink(target: strongSelf, selector: #selector(strongSelf.displayLinkDidUpdate))
+            strongSelf.updater?.add(to: .current, forMode: RunLoop.Mode.common)
+            strongSelf.updater?.isPaused = false
+        }
     }
     
     public static var cachedInternet: Bool?

--- a/Slide for Reddit/LinkCellView.swift
+++ b/Slide for Reddit/LinkCellView.swift
@@ -710,9 +710,6 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                 self.innerView.addGestureRecognizer(longPress!)
             }
             
-            self.awardView.addTapGestureRecognizer {
-                self.showAwardMenu()
-            }
             addTouch = true
         }
         
@@ -1524,6 +1521,9 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                         flairView.sd_setImage(with: urlAsURL)
                         flairView.sizeAnchors == CGSize.square(size: 15)
                         awardView.addArrangedSubview(flairView)
+                        flairView.addTapGestureRecognizer {
+                            self.showAwardMenu()
+                        }
                     }
                 }
             }
@@ -1534,6 +1534,10 @@ class LinkCellView: UICollectionViewCell, UIViewControllerPreviewingDelegate, UI
                     $0.text = "\(awardCount) Awards"
                     $0.textColor = ColorUtil.theme.fontColor
                 }
+                label.addTapGestureRecognizer {
+                    self.showAwardMenu()
+                }
+
                 awardView.addArrangedSubview(label)
             }
             awardView.addArrangedSubview(UIView()) //right spacer

--- a/Slide for Reddit/MainViewController.swift
+++ b/Slide for Reddit/MainViewController.swift
@@ -193,7 +193,7 @@ class MainViewController: ColorMuxPagingViewController, UINavigationControllerDe
                 if AccountController.isLoggedIn && currentAccount == AccountController.currentName { //Ensure the user did not switch accounts before applying subs
                     var allSubs = [String]()
                     allSubs.append(contentsOf: newSubs.map { $0.displayName })
-                    allSubs.append(contentsOf: newMultis.map { "/m/" + $0.displayName })
+                    allSubs.append(contentsOf: newMultis.map { "/m/" + $0.displayName.replacingOccurrences(of: " ", with: "_") })
                     let currentSubs = Subscriptions.subreddits
                     var finalSubs = [String]()
                     finalSubs.append(contentsOf: allSubs)

--- a/Slide for Reddit/MediaViewController.swift
+++ b/Slide for Reddit/MediaViewController.swift
@@ -139,6 +139,17 @@ class MediaViewController: UIViewController, MediaVCDelegate, UIPopoverPresentat
                         }
                     }
                 }
+                if let subVC = self as? ContentListingViewController {
+                    for index in subVC.tableView.indexPathsForVisibleItems {
+                        if let cell = subVC.tableView.cellForItem(at: index) as? LinkCellView {
+                            cell.endVideos()
+                            subVC.currentPlayingIndex = subVC.currentPlayingIndex.filter({ (included) -> Bool in
+                                return included.row != index.row
+                            })
+                        }
+                    }
+                }
+
             }
             if ContentType.isGif(uri: url) {
                 if !link.videoPreview.isEmpty() && !ContentType.isGfycat(uri: url) {

--- a/Slide for Reddit/MessageCellView.swift
+++ b/Slide for Reddit/MessageCellView.swift
@@ -138,7 +138,7 @@ class MessageCellView: UICollectionViewCell, UIGestureRecognizerDelegate, TextDi
     var cancelled = false
     
     public static func getTitleText(message: RMessage) -> NSAttributedString {
-        let titleText = NSMutableAttributedString.init(string: message.wasComment ? message.linkTitle : message.subject.escapeHTML, attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 18, submission: false), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): !ActionStates.isRead(s: message) ? GMColor.red500Color() : ColorUtil.theme.fontColor]))
+        let titleText = NSMutableAttributedString.init(string: message.wasComment ? message.linkTitle.unescapeHTML : message.subject.unescapeHTML, attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 18, submission: false), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): !ActionStates.isRead(s: message) ? GMColor.red500Color() : ColorUtil.theme.fontColor]))
         
         let endString = NSMutableAttributedString(string: "\(DateFormatter().timeSince(from: message.created, numericDates: true))  •  from \(message.author)", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): ColorUtil.theme.fontColor, convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 16, submission: false)]))
         

--- a/Slide for Reddit/ModLogCellView.swift
+++ b/Slide for Reddit/ModLogCellView.swift
@@ -1,0 +1,228 @@
+//
+//  ModLogCellView.swift
+//  Slide for Reddit
+//
+//  Created by Carlos Crane on 11/17/20.
+//  Copyright © 2020 Haptic Apps. All rights reserved.
+//
+
+import Anchorage
+import AudioToolbox
+import reddift
+import UIKit
+import YYText
+
+class ModlogCellView: UICollectionViewCell, UIGestureRecognizerDelegate, TextDisplayStackViewDelegate {
+    
+    func linkTapped(url: URL, text: String) {
+        if !text.isEmpty {
+            self.parentViewController?.showSpoiler(text)
+        } else {
+            self.parentViewController?.doShow(url: url, heroView: nil, finalSize: nil, heroVC: nil, link: RSubmission())
+        }
+    }
+
+    func linkLongTapped(url: URL) {
+        longBlocking = true
+        
+        let alertController = DragDownAlertMenu(title: "Link options", subtitle: url.absoluteString, icon: url.absoluteString)
+        
+        alertController.addAction(title: "Share URL", icon: UIImage(sfString: SFSymbol.squareAndArrowUp, overrideString: "share")!.menuIcon()) {
+            let shareItems: Array = [url]
+            let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: shareItems, applicationActivities: nil)
+            activityViewController.popoverPresentationController?.sourceView = self.contentView
+            self.parentViewController?.present(activityViewController, animated: true, completion: nil)
+        }
+        
+        alertController.addAction(title: "Copy URL", icon: UIImage(sfString: SFSymbol.docOnDocFill, overrideString: "copy")!.menuIcon()) {
+            UIPasteboard.general.setValue(url, forPasteboardType: "public.url")
+            BannerUtil.makeBanner(text: "URL Copied", seconds: 5, context: self.parentViewController)
+        }
+        
+        alertController.addAction(title: "Open in default app", icon: UIImage(sfString: SFSymbol.safariFill, overrideString: "nav")!.menuIcon()) {
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
+        }
+        
+        let open = OpenInChromeController.init()
+        if open.isChromeInstalled() {
+            alertController.addAction(title: "Open in Chrome", icon: UIImage(named: "world")!.menuIcon()) {
+                _ = open.openInChrome(url, callbackURL: nil, createNewTab: true)
+            }
+        }
+        
+        if #available(iOS 10.0, *) {
+            HapticUtility.hapticActionStrong()
+        } else if SettingValues.hapticFeedback {
+            AudioServicesPlaySystemSound(1519)
+        }
+        
+        if parentViewController != nil {
+            alertController.show(parentViewController!)
+        }
+    }
+
+    var text: TextDisplayStackView!
+    var single = false
+
+    var longBlocking = false
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let topmargin = 0
+        let bottommargin = 2
+        let leftmargin = 0
+        let rightmargin = 0
+        
+        let f = self.contentView.frame
+        let fr = f.inset(by: UIEdgeInsets(top: CGFloat(topmargin), left: CGFloat(leftmargin), bottom: CGFloat(bottommargin), right: CGFloat(rightmargin)))
+        self.contentView.frame = fr
+    }
+
+    var content: NSAttributedString?
+    var hasText = false
+
+    var full = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.contentView.layoutMargins = UIEdgeInsets.init(top: 2, left: 0, bottom: 0, right: 0)
+        self.text = TextDisplayStackView.init(fontSize: 16, submission: false, color: ColorUtil.accentColorForSub(sub: ""), width: frame.width - 16, delegate: self)
+        self.contentView.addSubview(text)
+        
+        text.topAnchor /==/ contentView.topAnchor + CGFloat(8)
+        text.bottomAnchor /<=/ contentView.bottomAnchor + CGFloat(8)
+        text.rightAnchor /==/ contentView.rightAnchor - CGFloat(8)
+        
+        self.text.leftAnchor /==/ self.contentView.leftAnchor + 8
+
+        self.contentView.backgroundColor = ColorUtil.theme.foregroundColor
+    }
+    
+    var lsC: [NSLayoutConstraint] = []
+
+    func setLogItem(logItem: RModlogItem, parent: UIViewController & MediaVCDelegate, nav: UIViewController?, width: CGFloat) {
+        parentViewController = parent
+        if navViewController == nil && nav != nil {
+            navViewController = nav
+        }
+        self.logItem = logItem
+
+        let messageClick = UITapGestureRecognizer(target: self, action: #selector(ModlogCellView.didClick(sender:)))
+        let messageLongClick = UILongPressGestureRecognizer(target: self, action: #selector(ModlogCellView.showMenu(_:)))
+        messageLongClick.minimumPressDuration = 0.36
+        messageLongClick.delegate = self
+        messageLongClick.cancelsTouchesInView = false
+        messageClick.delegate = self
+        self.addGestureRecognizer(messageClick)
+        self.addGestureRecognizer(messageLongClick)
+
+        let titleText = ModlogCellView.getTitleText(item: logItem)
+        text.estimatedWidth = self.contentView.frame.size.width - 16
+        text.setTextWithTitleHTML(titleText, htmlString: logItem.targetTitle)
+    }
+    
+    @objc func didClick(sender: AnyObject) {
+        guard let logItem = logItem else { return }
+        let url = "https://www.reddit.com\(logItem.permalink)"
+        VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: url)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
+    }
+
+    var timer: Timer?
+    var cancelled = false
+    
+    public static func getTitleText(item: RModlogItem) -> NSAttributedString {
+        let titleText = NSMutableAttributedString.init(string: "\(item.action)- \(item.details)", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 18, submission: false), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): ColorUtil.theme.fontColor]))
+        
+        let endString = NSMutableAttributedString(string: "\(DateFormatter().timeSince(from: item.created, numericDates: true))  •  removed by \(item.mod)", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): ColorUtil.theme.fontColor, convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 16, submission: false)]))
+        
+        var color = ColorUtil.getColorForSub(sub: item.subreddit)
+        if color == ColorUtil.baseColor {
+            color = ColorUtil.theme.fontColor
+        }
+
+        let subString = NSMutableAttributedString(string: "r/\(item.subreddit)", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 16, submission: false), convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): color]))
+        
+        let infoString = NSMutableAttributedString()
+        infoString.append(endString)
+        infoString.append(NSAttributedString.init(string: "  •  ", attributes: convertToOptionalNSAttributedStringKeyDictionary([convertFromNSAttributedStringKey(NSAttributedString.Key.foregroundColor): ColorUtil.theme.fontColor, convertFromNSAttributedStringKey(NSAttributedString.Key.font): FontGenerator.fontOfSize(size: 16, submission: false)])))
+        infoString.append(subString)
+        
+        titleText.append(NSAttributedString(string: "\n"))
+        titleText.append(infoString)
+        return titleText
+    }
+
+    @objc func showLongMenu() {
+        timer!.invalidate()
+        if longBlocking {
+            self.longBlocking = false
+            return
+        }
+        if !self.cancelled {
+           // TODO: - show menu
+            //read reply full thread
+            if #available(iOS 10.0, *) {
+                HapticUtility.hapticActionStrong()
+            } else if SettingValues.hapticFeedback {
+                AudioServicesPlaySystemSound(1519)
+            }
+            if let item = self.logItem {
+                let alertController = DragDownAlertMenu(title: "Modlog Item", subtitle: item.targetTitle.unescapeHTML, icon: nil)
+
+                alertController.addAction(title: "View author profile", icon: UIImage(sfString: SFSymbol.personFill, overrideString: "profile")!.menuIcon()) {
+                    let url = "https://www.reddit.com/u/\(item.targetAuthor)"
+                    VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: url)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
+                }
+
+                alertController.addAction(title: "View original content", icon: UIImage(sfString: SFSymbol.bubbleLeftAndBubbleRightFill, overrideString: "comments")!.menuIcon()) {
+                    let url = "https://www.reddit.com\(item.permalink)"
+                    VCPresenter.showVC(viewController: RedditLink.getViewControllerForURL(urlS: URL.initPercent(string: url)!), popupIfPossible: true, parentNavigationController: self.parentViewController?.navigationController, parentViewController: self.parentViewController)
+                }
+
+                alertController.show(parentViewController)
+            }
+        }
+    }
+
+    @objc func showMenu(_ sender: UILongPressGestureRecognizer) {
+        if sender.state == UIGestureRecognizer.State.began {
+            cancelled = false
+            timer = Timer.scheduledTimer(timeInterval: 0.36,
+                    target: self,
+                    selector: #selector(self.showLongMenu),
+                    userInfo: nil,
+                    repeats: false)
+        }
+        if sender.state == UIGestureRecognizer.State.ended {
+            timer!.invalidate()
+            cancelled = true
+            longBlocking = false
+        }
+    }
+
+    var registered: Bool = false
+    var currentLink: URL?
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var logItem: RModlogItem?
+    public var parentViewController: (UIViewController & MediaVCDelegate)?
+    public var navViewController: UIViewController?
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+private func convertToOptionalNSAttributedStringKeyDictionary(_ input: [String: Any]?) -> [NSAttributedString.Key: Any]? {
+    guard let input = input else { return nil }
+    return Dictionary(uniqueKeysWithValues: input.map { key, value in (NSAttributedString.Key(rawValue: key), value) })
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+private func convertFromNSAttributedStringKey(_ input: NSAttributedString.Key) -> String {
+    return input.rawValue
+}

--- a/Slide for Reddit/ModalMediaViewController.swift
+++ b/Slide for Reddit/ModalMediaViewController.swift
@@ -65,7 +65,7 @@ class ModalMediaViewController: UIViewController {
             titleView.numberOfLines = 0
             
             if commentCallback != nil {
-                titleView.addTapGestureRecognizer { [weak self] in
+                titleView.addTapGestureRecognizer { [weak self] (_) in
                     guard let strongSelf = self else { return }
                     strongSelf.dismiss(animated: false) {
                         strongSelf.commentCallback?()

--- a/Slide for Reddit/ModerationOverviewViewController.swift
+++ b/Slide for Reddit/ModerationOverviewViewController.swift
@@ -1,0 +1,70 @@
+//
+//  ModerationOverviewViewController.swift
+//  Slide for Reddit
+//
+//  Created by Carlos Crane on 11/16/20.
+//  Copyright © 2020 Haptic Apps. All rights reserved.
+//
+
+import RealmSwift
+import reddift
+import UIKit
+import UserNotifications
+
+class ModerationOverviewViewController: UITableViewController {
+    
+    var subs: [String]
+    
+    init() {
+        self.subs = ["All moderated subs"]
+        self.subs.append(contentsOf: AccountController.modSubs)
+        super.init(style: .plain)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupBaseBarColors()
+        if #available(iOS 13.0, *) {
+            self.isModalInPresentation = true
+        }
+    }
+    
+    override func loadView() {
+        super.loadView()
+        
+        self.view.backgroundColor = ColorUtil.theme.backgroundColor
+
+        self.title = "Subs you Moderate"
+        self.tableView.separatorStyle = .none
+        
+        self.tableView.register(SubredditCellView.classForCoder(), forCellReuseIdentifier: "sub")
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 75
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "sub") as? SubredditCellView
+        cell?.setSubreddit(subreddit: subs[indexPath.row], nav: self.navigationController)
+        return cell!
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let vc = ModerationViewController(indexPath.row == 0 ? "mod" : subs[indexPath.row])
+        VCPresenter.showVC(viewController: vc, popupIfPossible: true, parentNavigationController: self.navigationController, parentViewController: self)
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0: return self.subs.count //+ 1
+        default: fatalError("Unknown number of sections")
+        }
+    }
+    
+}

--- a/Slide for Reddit/ModerationViewController.swift
+++ b/Slide for Reddit/ModerationViewController.swift
@@ -15,6 +15,7 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
     var content: [String] = ["Mod Mail", "Mod Mail Unread"]
     var isReload = false
     var session: Session?
+    var subreddit: String
 
     var vCs: [UIViewController] = []
 
@@ -31,16 +32,17 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
         }
     }
 
-    public init() {
+    public init(_ subreddit: String) {
         self.session = (UIApplication.shared.delegate as! AppDelegate).session
-
+        self.subreddit = subreddit
         vCs.append(ContentListingViewController.init(dataSource: ModMailContributionLoader(false)))
         vCs.append(ContentListingViewController.init(dataSource: ModMailContributionLoader(true)))
 
-        for place in AccountController.modSubs {
-            content.append(place)
-            vCs.append(ContentListingViewController.init(dataSource: ModQueueContributionLoader(subreddit: place)))
-        }
+        content.append("Mod Queue")
+        vCs.append(ContentListingViewController.init(dataSource: ModQueueContributionLoader(subreddit: subreddit)))
+
+        content.append("Mod Log")
+        vCs.append(ContentListingViewController.init(dataSource: ModlogContributionLoader(subreddit: subreddit)))
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
     }
 
@@ -59,7 +61,7 @@ class ModerationViewController: UIPageViewController, UIPageViewControllerDataSo
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.title = "Moderation"
+        self.title = "r/\(subreddit)"
         navigationController?.setNavigationBarHidden(false, animated: true)
         setupBaseBarColors()
     }

--- a/Slide for Reddit/ModlogContributionLoader.swift
+++ b/Slide for Reddit/ModlogContributionLoader.swift
@@ -1,0 +1,76 @@
+//
+//  ModlogContributionLoader.swift
+//  Slide for Reddit
+//
+//  Created by Carlos Crane on 11/16/20.
+//  Copyright © 2020 Haptic Apps. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import reddift
+
+class ModlogContributionLoader: ContributionLoader {
+    func reset() {
+        content = []
+    }
+    
+    var subreddit: String
+    var color: UIColor
+    var canGetMore = true
+
+    init(subreddit: String) {
+        self.subreddit = subreddit
+        color = ColorUtil.getColorForSub(sub: "")
+        paginator = Paginator()
+        content = []
+    }
+    
+    var paginator: Paginator
+    var content: [Object]
+    var delegate: ContentListingViewController?
+    var paging = true
+    
+    func getData(reload: Bool) {
+        if delegate != nil {
+            do {
+                if reload {
+                    paginator = Paginator()
+                }
+                try delegate?.session?.getModLog(paginator, subreddit: Subreddit.init(subreddit: subreddit), completion: { (result) in
+                    switch result {
+                    case .failure(let error):
+                        print(error)
+                        self.delegate?.failed(error: error)
+                    case.success(let listing):
+                        let before = self.content.count
+
+                        listing.children.forEach { (thing) in
+                            if let thing = thing as? ModAction {
+                                let item = RModlogItem()
+                                item.action = thing.action
+                                item.created = Date(timeIntervalSince1970: thing.createdUtc) as NSDate
+                                item.details = thing.details
+                                item.id = thing.id
+                                item.mod = thing.mod
+                                item.permalink = thing.targetPermalink
+                                item.subreddit = thing.subreddit
+                                item.targetAuthor = thing.targetAuthor
+                                item.targetBody = thing.targetBody
+                                item.targetTitle = thing.targetTitle
+                                self.content.append(item)
+                            }
+                        }
+                        self.paginator = listing.paginator
+                        DispatchQueue.main.async {
+                            self.delegate?.doneLoading(before: before, filter: false)
+                        }
+                    }
+                })
+            } catch {
+                print(error)
+            }
+
+        }
+    }
+}

--- a/Slide for Reddit/NavigationHomeViewController.swift
+++ b/Slide for Reddit/NavigationHomeViewController.swift
@@ -972,9 +972,11 @@ class CurrentAccountHeaderView: UIView {
             $0.accessibilityIgnoresInvertColors = true
         }
         if !SettingValues.flatMode {
-            $0.elevate(elevation: 2.0)
             $0.layer.cornerRadius = 10
             $0.clipsToBounds = true
+        }
+        if !SettingValues.reduceElevation {
+            $0.elevate(elevation: 2.0)
         }
     }
     

--- a/Slide for Reddit/NavigationHomeViewController.swift
+++ b/Slide for Reddit/NavigationHomeViewController.swift
@@ -1126,8 +1126,7 @@ extension CurrentAccountHeaderView {
             )
         }()
         
-        contentView.addTapGestureRecognizer {
-            [weak self] in
+        contentView.addTapGestureRecognizer { [weak self] (_) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.accountHeaderView(strongSelf.parent!, didRequestProfilePageAtIndex: 0)
         }
@@ -1335,7 +1334,7 @@ class AccountShortcutsView: UIView {
             if !action.needsAccount() || AccountController.isLoggedIn {
                 cellStack.addArrangedSubview(UITableViewCell().then {
                     $0.configure(text: action.getTitle(), image: action.getImage())
-                    $0.addTapGestureRecognizer {
+                    $0.addTapGestureRecognizer { (_) in
                         if let delegate = self.delegate, let parent = self.parent {
                             delegate.navigation(parent, didRequestAction: action)
                         }
@@ -1350,7 +1349,7 @@ class AccountShortcutsView: UIView {
         
         cellStack.addArrangedSubview(UITableViewCell().then {
             $0.configure(text: "More shortcuts", image: UIImage(sfString: SFSymbol.ellipsis, overrideString: "moreh")!.menuIcon())
-            $0.addTapGestureRecognizer {
+            $0.addTapGestureRecognizer { (_) in
                 let optionMenu = DragDownAlertMenu(title: "Slide shortcuts", subtitle: "Displayed shortcuts can be changed in Settings", icon: nil)
                 for action in SettingValues.NavigationHeaderActions.cases {
                     if !action.needsAccount() || AccountController.isLoggedIn {

--- a/Slide for Reddit/NavigationHomeViewController.swift
+++ b/Slide for Reddit/NavigationHomeViewController.swift
@@ -235,7 +235,9 @@ class NavigationHomeViewController: UIViewController {
         navigationController?.setToolbarHidden(false, animated: false)
         self.navigationController?.toolbar.barTintColor = ColorUtil.theme.foregroundColor
         
-        self.tableView.setContentOffset(CGPoint.zero, animated: false)
+        if SettingValues.scrollSidebar {
+            self.tableView.setContentOffset(CGPoint.zero, animated: false)
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -368,12 +370,14 @@ extension NavigationHomeViewController: UITableViewDelegate, UITableViewDataSour
             let sub = cell.subreddit
             self.accountHeader?.delegate?.navigation(self, didRequestSubreddit: sub)
         }
-        searchBar.text = ""
-        searchBar.endEditing(true)
-        filteredContent = []
-        isSearching = false
-        tableView.reloadData()
-        tableView.deselectRow(at: indexPath, animated: true)
+        if SettingValues.scrollSidebar {
+            searchBar.text = ""
+            searchBar.endEditing(true)
+            filteredContent = []
+            isSearching = false
+            tableView.reloadData()
+            tableView.deselectRow(at: indexPath, animated: true)
+        }
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/Slide for Reddit/NavigationHomeViewController.swift
+++ b/Slide for Reddit/NavigationHomeViewController.swift
@@ -662,7 +662,9 @@ extension NavigationHomeViewController: UISearchBarDelegate {
                                 let communityIcon = sub["data"]["community_icon"].stringValue
                                 let keyColor = sub["data"]["key_color"].stringValue
                                 Subscriptions.subIcons[subName.lowercased()] = icon == "" ? communityIcon : icon
-                                Subscriptions.subColors[subName.lowercased()] = keyColor
+                                if keyColor.lowercased() != "#ffffff" && keyColor != "#000000" {
+                                    Subscriptions.subColors[subName.lowercased()] = keyColor
+                                }
                                 if self.suggestions.contains(subName) {
                                     continue
                                 }

--- a/Slide for Reddit/Onboarding2/OnboardingViewController.swift
+++ b/Slide for Reddit/Onboarding2/OnboardingViewController.swift
@@ -50,7 +50,7 @@ class OnboardingViewController: UIViewController {
 
         setupConstraints()
         
-        finishButton.addTapGestureRecognizer {
+        finishButton.addTapGestureRecognizer { (_) in
             self.dismiss(animated: true, completion: nil)
         }
         

--- a/Slide for Reddit/PagingTitleCollectionView.swift
+++ b/Slide for Reddit/PagingTitleCollectionView.swift
@@ -270,9 +270,7 @@ class SubredditTitleCollectionViewCell: UICollectionViewCell {
         selectedBackgroundView = selectedView
         
         self.icon.contentMode = .center
-        if subreddit.contains("m/") {
-            self.icon.image = SubredditCellView.defaultIconMulti
-        } else if subreddit.lowercased() == "all" {
+         if subreddit.lowercased() == "all" {
             self.icon.image = SubredditCellView.allIcon
         } else if subreddit.lowercased() == "frontpage" {
             self.icon.image = SubredditCellView.frontpageIcon
@@ -282,6 +280,8 @@ class SubredditTitleCollectionViewCell: UICollectionViewCell {
             self.icon.contentMode = .scaleAspectFill
             self.icon.image = UIImage()
             self.icon.sd_setImage(with: URL(string: icon.unescapeHTML), completed: nil)
+        } else if subreddit.contains("m/") {
+            self.icon.image = SubredditCellView.defaultIconMulti
         } else {
             self.icon.image = SubredditCellView.defaultIcon
         }

--- a/Slide for Reddit/ProfileInfoViewController.swift
+++ b/Slide for Reddit/ProfileInfoViewController.swift
@@ -78,9 +78,11 @@ class ProfileInfoViewController: UIViewController {
             $0.accessibilityIgnoresInvertColors = true
         }
         if !SettingValues.flatMode {
-            $0.elevate(elevation: 2.0)
             $0.layer.cornerRadius = 10
             $0.clipsToBounds = true
+        }
+        if !SettingValues.reduceElevation {
+            $0.elevate(elevation: 2.0)
         }
     }
     

--- a/Slide for Reddit/ProfileInfoViewController.swift
+++ b/Slide for Reddit/ProfileInfoViewController.swift
@@ -233,7 +233,7 @@ extension ProfileInfoViewController {
                         for trophy in trophies {
                             let b = self.generateButtons(trophy: trophy)
                             b.sizeAnchors /==/ CGSize(width: 70, height: 70)
-                            b.addTapGestureRecognizer(action: {
+                            b.addTapGestureRecognizer(action: { _ in
                                 if trophy.url != nil {
                                     var trophyURL = trophy.url!.absoluteString
                                     if !trophyURL.contains("reddit.com") {
@@ -576,7 +576,7 @@ class ProfileHeaderView: UIView {
     }
     
     func setupActions() {
-        friendCell.addTapGestureRecognizer { [weak self] in
+        friendCell.addTapGestureRecognizer { [weak self] (_) in
             guard let strongSelf = self else { return }
             if strongSelf.user?.isFriend ?? false {
                 strongSelf.delegate?.didRequestRemoveFriend()
@@ -584,15 +584,15 @@ class ProfileHeaderView: UIView {
                 strongSelf.delegate?.didRequestAddFriend()
             }
         }
-        messageCell.addTapGestureRecognizer { [weak self] in
+        messageCell.addTapGestureRecognizer { [weak self] (_) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.didRequestPrivateMessage()
         }
-        colorCell.addTapGestureRecognizer { [weak self] in
+        colorCell.addTapGestureRecognizer { [weak self] (_) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.didRequestSetColor()
         }
-        tagCell.addTapGestureRecognizer { [weak self] in
+        tagCell.addTapGestureRecognizer { [weak self] (_) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.didRequestEditTag()
         }

--- a/Slide for Reddit/ProfileViewController.swift
+++ b/Slide for Reddit/ProfileViewController.swift
@@ -422,5 +422,6 @@ extension ProfileViewController {
 extension ProfileViewController: UIColorPickerViewControllerDelegate {
     func colorPickerViewControllerDidSelectColor(_ viewController: UIColorPickerViewController) {
         newColor = viewController.selectedColor
+        ColorUtil.setColorForUser(name: name, color: newColor)
     }
 }

--- a/Slide for Reddit/RealmDataWrappers.swift
+++ b/Slide for Reddit/RealmDataWrappers.swift
@@ -206,6 +206,13 @@ class RealmDataWrapper {
                     awardArray.append("\(award["count"] as? Int ?? 0)")
                     awardArray.append(award["description"] as? String ?? "")
                     awardArray.append("\(award["coin_price"] as? Int ?? 0)")
+                    
+                    //HD icon
+                    if let awards = award["resized_icons"] as? [AnyObject], awards.count > 1, let url = awards[awards.count - 1]["url"] as? String {
+                        awardArray.append(url.unescapeHTML)
+                    } else {
+                        awardArray.append(award["icon_url"] as? String ?? "")
+                    }
                     jsonDict[name] = awardArray
                 }
             }
@@ -352,6 +359,13 @@ class RealmDataWrapper {
                     awardArray.append("\(award["count"] as? Int ?? 0)")
                     awardArray.append(award["description"] as? String ?? "")
                     awardArray.append("\(award["coin_price"] as? Int ?? 0)")
+                    
+                    //HD icon
+                    if let awards = award["resized_icons"] as? [AnyObject], awards.count > 1, let url = awards[awards.count - 1]["url"] as? String {
+                        awardArray.append(url.unescapeHTML)
+                    } else {
+                        awardArray.append(award["icon_url"] as? String ?? "")
+                    }
                     jsonDict[name] = awardArray
                 }
             }

--- a/Slide for Reddit/RealmDataWrappers.swift
+++ b/Slide for Reddit/RealmDataWrappers.swift
@@ -740,6 +740,28 @@ class RMessage: Object {
     }
 }
 
+class RModlogItem: Object {
+    override class func primaryKey() -> String? {
+        return "id"
+    }
+    
+    @objc dynamic var id = ""
+    @objc dynamic var mod = ""
+    @objc dynamic var targetBody = ""
+    @objc dynamic var created = NSDate(timeIntervalSince1970: 1)
+    @objc dynamic var subreddit = ""
+    @objc dynamic var targetTitle = ""
+    @objc dynamic var permalink = ""
+    @objc dynamic var details = ""
+    @objc dynamic var action = ""
+    @objc dynamic var targetAuthor = ""
+    @objc dynamic var subject = ""
+    
+    func getId() -> String {
+        return id
+    }
+}
+
 class RComment: Object {
     override class func primaryKey() -> String? {
         return "id"

--- a/Slide for Reddit/ReplyViewController.swift
+++ b/Slide for Reddit/ReplyViewController.swift
@@ -812,7 +812,7 @@ class ReplyViewController: MediaViewController, UITextViewDelegate {
             }
             text2.isEditable = false
 
-            text2.addTapGestureRecognizer {
+            text2.addTapGestureRecognizer { (_) in
                 let search = SubredditFindReturnViewController(includeSubscriptions: true, includeCollections: false, includeTrending: false, subscribe: false, callback: { (subreddit) in
                     text2.text = subreddit
                     self.subreddit = subreddit
@@ -839,7 +839,7 @@ class ReplyViewController: MediaViewController, UITextViewDelegate {
                 text3.textContainer.maximumNumberOfLines = 0
                 
                 if type == .SUBMIT_IMAGE {
-                    text3.addTapGestureRecognizer {
+                    text3.addTapGestureRecognizer { (_) in
                         self.toolbar?.uploadImage(UIButton())
                     }
                     text3.placeholder = "Tap to choose an image"

--- a/Slide for Reddit/SettingValues.swift
+++ b/Slide for Reddit/SettingValues.swift
@@ -95,6 +95,7 @@ class SettingValues {
     public static let pref_linkAlwaysThumbnail = "LINK_ALWAYS_THUMBNAIL"
     public static let pref_actionbarMode = "ACTIONBAR_MODE"
     public static let pref_flatMode = "FLAT_MODE"
+    public static let pref_reduceElevation = "REDUCE_ELEVATION"
     public static let pref_bottomBarHidden = "BOTTOM_BAR_HIDDEN"
     public static let pref_widerIndicators = "WIDE_INDICATORS"
     public static let pref_blackShadowbox = "BLACK_SHADOWBOX"
@@ -187,6 +188,7 @@ class SettingValues {
     public static var actionBarMode = ActionBarMode.FULL
     public static var autoPlayMode = AutoPlay.ALWAYS
     public static var flatMode = false
+    public static var reduceElevation = false
     public static var fabType = FabType.HIDE_READ
     public static var pictureMode = "PICTURE_MODE"
     public static var hideImageSelftext = false
@@ -647,6 +649,7 @@ class SettingValues {
         SettingValues.autoPlayMode = AutoPlay.init(rawValue: settings.string(forKey: SettingValues.pref_autoPlayMode) ?? "always") ?? .ALWAYS
         SettingValues.browser = settings.string(forKey: SettingValues.pref_browser) ?? SettingValues.BROWSER_INTERNAL
         SettingValues.flatMode = settings.bool(forKey: SettingValues.pref_flatMode)
+        SettingValues.reduceElevation = settings.bool(forKey: SettingValues.pref_reduceElevation)
         SettingValues.postImageMode = PostImageMode.init(rawValue: settings.string(forKey: SettingValues.pref_postImageMode) ?? "full") ?? .CROPPED_IMAGE
         SettingValues.fabType = FabType.init(rawValue: settings.string(forKey: SettingValues.pref_fabType) ?? "hide") ?? .HIDE_READ
         SettingValues.commentGesturesMode = CellGestureMode.init(rawValue: settings.string(forKey: SettingValues.pref_commentGesturesMode) ?? "half") ?? .HALF

--- a/Slide for Reddit/SettingValues.swift
+++ b/Slide for Reddit/SettingValues.swift
@@ -714,7 +714,7 @@ class SettingValues {
         detailViewController.comments.setTitle("Join the discussion!", for: UIControl.State.normal)
         detailViewController.comments.titleLabel?.font = UIFont.boldSystemFont(ofSize: 12)
         detailViewController.comments.contentHorizontalAlignment = .left
-        detailViewController.comments.addTapGestureRecognizer {
+        detailViewController.comments.addTapGestureRecognizer { (_) in
             detailViewController.dismiss(animated: true) {
                 VCPresenter.openRedditLink(submission.permalink, parentVC.navigationController, parentVC)
             }

--- a/Slide for Reddit/SettingValues.swift
+++ b/Slide for Reddit/SettingValues.swift
@@ -144,6 +144,7 @@ class SettingValues {
     public static let pref_disableSubredditPopupIpad = "DISABLE_SUB_POPUP_IPAD"
     public static let pref_portraitMultiColumnCount = "MULTICOLUMN_COUNT_PORTRAIT"
     public static let pref_gfycatAPI = "USE_GFYCAT_API"
+    public static let pref_scrollSidebar = "SCROLL_SIDEBAR"
 
     public static let BROWSER_INTERNAL = "internal"
     public static let BROWSER_SAFARI_INTERNAL_READABILITY = "readability"
@@ -216,6 +217,7 @@ class SettingValues {
     public static var disableBanner = false
     public static var newIndicator = false
     public static var typeInTitle = true
+    public static var scrollSidebar = false
 
     public static var enlargeLinks = true
     public static var noImages = false
@@ -522,6 +524,8 @@ class SettingValues {
                 break
             }
         }
+        
+        SettingValues.scrollSidebar = settings.object(forKey: SettingValues.pref_scrollSidebar) == nil ? true : settings.bool(forKey: SettingValues.pref_scrollSidebar)
 
         SettingValues.postFontOffset = settings.object(forKey: SettingValues.pref_postFontSize) == nil ? 0 : settings.integer(forKey: SettingValues.pref_postFontSize)
         SettingValues.commentFontOffset = settings.object(forKey: SettingValues.pref_commentFontSize) == nil ? -2 : settings.integer(forKey: SettingValues.pref_commentFontSize)

--- a/Slide for Reddit/SettingsDonate.swift
+++ b/Slide for Reddit/SettingsDonate.swift
@@ -108,7 +108,7 @@ class SettingsDonate: UIViewController, MFMailComposeViewControllerDelegate {
         lunch.font = UIFont.boldSystemFont(ofSize: 16)
         lunch.textAlignment = .center
 
-        bagel.addTapGestureRecognizer {
+        bagel.addTapGestureRecognizer { (_) in
             IAPHandlerTip.shared.purchaseMyProduct(index: 0)
             self.alertController = UIAlertController(title: "Processing your tip!\n\n\n", message: nil, preferredStyle: .alert)
             
@@ -121,7 +121,7 @@ class SettingsDonate: UIViewController, MFMailComposeViewControllerDelegate {
             self.present(self.alertController!, animated: true, completion: nil)
         }
         
-        coffee.addTapGestureRecognizer {
+        coffee.addTapGestureRecognizer { (_) in
             IAPHandlerTip.shared.purchaseMyProduct(index: 1)
             self.alertController = UIAlertController(title: "Processing your tip!\n\n\n", message: nil, preferredStyle: .alert)
             
@@ -134,7 +134,7 @@ class SettingsDonate: UIViewController, MFMailComposeViewControllerDelegate {
             self.present(self.alertController!, animated: true, completion: nil)
         }
 
-        lunch.addTapGestureRecognizer {
+        lunch.addTapGestureRecognizer { (_) in
             IAPHandlerTip.shared.purchaseMyProduct(index: 2)
             self.alertController = UIAlertController(title: "Processing your tip!\n\n\n", message: nil, preferredStyle: .alert)
             

--- a/Slide for Reddit/SettingsFont.swift
+++ b/Slide for Reddit/SettingsFont.swift
@@ -150,12 +150,12 @@ class SettingsFont: BubbleSettingTableViewController {
         submissionSize.textLabel?.text = "Font size"
 
         submissionWeight.textLabel?.text = "Font variant"
-        submissionWeight.addTapGestureRecognizer { [weak self] in
+        submissionWeight.addTapGestureRecognizer { [weak self] (_) in
             self?.weightCellWasTapped(submission: true)
         }
 
         submissionFont.textLabel?.text = "Font"
-        submissionFont.addTapGestureRecognizer { [weak self] in
+        submissionFont.addTapGestureRecognizer { [weak self] (_) in
             self?.submissionFontCellWasTapped()
         }
 
@@ -186,12 +186,12 @@ class SettingsFont: BubbleSettingTableViewController {
         slider.heightAnchor /==/ 60
         slider.bottomAnchor /==/ commentSize.contentView.bottomAnchor
         commentFont.textLabel?.text = "Font"
-        commentFont.addTapGestureRecognizer { [weak self] in
+        commentFont.addTapGestureRecognizer { [weak self] (_) in
             self?.commentFontCellWasTapped()
         }
 
         commentWeight.textLabel?.text = "Font variant"
-        commentWeight.addTapGestureRecognizer { [weak self] in
+        commentWeight.addTapGestureRecognizer { [weak self] (_) in
             self?.weightCellWasTapped(submission: false)
         }
 

--- a/Slide for Reddit/SettingsFont.swift
+++ b/Slide for Reddit/SettingsFont.swift
@@ -426,9 +426,35 @@ extension SettingsFont {
         self.key = .commentFont
 
         if #available(iOS 13, *) {
-            let vc = UIFontPickerViewController()
-            vc.delegate = self
-            VCPresenter.showVC(viewController: vc, popupIfPossible: false, parentNavigationController: self.navigationController, parentViewController: self)
+            let actionSheetController = DragDownAlertMenu(title: "Submission font", subtitle: "", icon: nil, themeColor: nil, full: true)
+
+            let fonts = FontMapping.sanFranciscoVariants
+
+            let selected = UIImage(sfString: SFSymbol.checkmarkCircle, overrideString: "selected")!.menuIcon()
+            let submission = false
+            
+            // Prune out the weights that aren't available for the selected font
+            for font in fonts {
+                actionSheetController.addAction(title: font.displayedName, icon: font.storedName.contains(FontGenerator.fontOfSize(size: 16, submission: submission).fontName) ? selected : nil) {
+                    UserDefaults.standard.set(font.storedName, forKey: submission ? "postfont" : "commentfont")
+                    
+                    UserDefaults.standard.synchronize()
+                    FontGenerator.initialize()
+                    CachedTitle.titleFont = FontGenerator.fontOfSize(size: CachedTitle.baseFontSize, submission: true)
+                    CachedTitle.titles.removeAll()
+                    self.refresh()
+                }
+            }
+            
+            actionSheetController.addAction(title: "Custom font", icon: nil) {
+                let config = UIFontPickerViewController.Configuration()
+                config.includeFaces = true
+                let vc = UIFontPickerViewController(configuration: config)
+                vc.delegate = self
+                self.present(vc, animated: true)
+            }
+
+            actionSheetController.show(self)
         } else {
             let vc = FontSelectionTableViewController()
             vc.title = "Comment Font"

--- a/Slide for Reddit/SettingsGeneral.swift
+++ b/Slide for Reddit/SettingsGeneral.swift
@@ -167,6 +167,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         cell.textLabel?.textColor = ColorUtil.theme.fontColor
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.lineBreakMode = .byWordWrapping
+        cell.detailTextLabel?.numberOfLines = 0
         if let s = switchV {
             s.isOn = isOn
             s.addTarget(self, action: #selector(SettingsGeneral.switchIsChanged(_:)), for: UIControl.Event.valueChanged)

--- a/Slide for Reddit/SettingsGeneral.swift
+++ b/Slide for Reddit/SettingsGeneral.swift
@@ -225,7 +225,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         self.commentLimit.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         self.commentLimit.backgroundColor = ColorUtil.theme.foregroundColor
         self.commentLimit.textLabel?.textColor = ColorUtil.theme.fontColor
-        self.commentLimit.contentView.addTapGestureRecognizer {
+        self.commentLimit.contentView.addTapGestureRecognizer { (_) in
             self.showCountMenu(false)
         }
 
@@ -234,7 +234,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         self.postLimit.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         self.postLimit.backgroundColor = ColorUtil.theme.foregroundColor
         self.postLimit.textLabel?.textColor = ColorUtil.theme.fontColor
-        self.postLimit.contentView.addTapGestureRecognizer {
+        self.postLimit.contentView.addTapGestureRecognizer { (_) in
             self.showCountMenu(true)
         }
 

--- a/Slide for Reddit/SettingsGeneral.swift
+++ b/Slide for Reddit/SettingsGeneral.swift
@@ -28,6 +28,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
     var alwaysShowHeader: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "head")
     var commentLimit: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "cl")
     var postLimit: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "pl")
+    var scrollSidebar: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "scroll")
 
     var postSorting: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "post")
     var commentSorting: InsetCell = InsetCell.init(style: .subtitle, reuseIdentifier: "comment")
@@ -66,6 +67,9 @@ class SettingsGeneral: BubbleSettingTableViewController {
     var notificationsSwitch = UISwitch().then {
         $0.onTintColor = ColorUtil.baseAccent
     }
+    var scrollSidebarSwitch = UISwitch().then {
+        $0.onTintColor = ColorUtil.baseAccent
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -101,6 +105,9 @@ class SettingsGeneral: BubbleSettingTableViewController {
         } else if changed == hapticFeedback {
             SettingValues.hapticFeedback = !changed.isOn
             UserDefaults.standard.set(!changed.isOn, forKey: SettingValues.pref_hapticFeedback)
+        } else if changed == scrollSidebarSwitch {
+            SettingValues.scrollSidebar = changed.isOn
+            UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_scrollSidebar)
         } else if changed == notificationsSwitch {
             SettingValues.notifications = changed.isOn
             UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_notifications)
@@ -188,6 +195,8 @@ class SettingsGeneral: BubbleSettingTableViewController {
         createCell(totallyCollapse, totallyCollapseSwitch, isOn: SettingValues.hideBottomBar, text: "Hide bottom bars on scroll")
         createCell(fullyHideNavbar, fullyHideNavbarSwitch, isOn: SettingValues.hideStatusBar, text: "Hide status bar on scroll")
         createCell(alwaysShowHeader, alwaysShowHeaderSwitch, isOn: SettingValues.alwaysShowHeader, text: "Show subreddit header")
+        createCell(scrollSidebar, scrollSidebarSwitch, isOn: SettingValues.scrollSidebar, text: "Reset sidebar automatically")
+
         self.alwaysShowHeader.detailTextLabel?.text = "When off, scrolling up past the first post will display the header"
         self.alwaysShowHeader.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         self.alwaysShowHeader.detailTextLabel?.numberOfLines = 0
@@ -219,6 +228,12 @@ class SettingsGeneral: BubbleSettingTableViewController {
         self.searchSorting.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         self.searchSorting.backgroundColor = ColorUtil.theme.foregroundColor
         self.searchSorting.textLabel?.textColor = ColorUtil.theme.fontColor
+       
+        self.scrollSidebar.textLabel?.text = "Reset Sidebar automatically"
+        self.scrollSidebar.detailTextLabel?.text = "Reset search and scroll to the top of the subreddit menu automatically"
+        self.scrollSidebar.detailTextLabel?.textColor = ColorUtil.theme.fontColor
+        self.scrollSidebar.backgroundColor = ColorUtil.theme.foregroundColor
+        self.scrollSidebar.textLabel?.textColor = ColorUtil.theme.fontColor
 
         self.commentLimit.textLabel?.text = "Number of comments to load"
         self.commentLimit.detailTextLabel?.text = "\(SettingValues.commentLimit) comments"
@@ -265,7 +280,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         }
         
         self.notifications.textLabel?.text = "New message notifications"
-        self.notifications.detailTextLabel?.text = "Check for new mail every 15 minutes"
+        self.notifications.detailTextLabel?.text = "Check for new mail when iOS allows Slide to wake from background"
         self.notifications.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         self.notifications.backgroundColor = ColorUtil.theme.foregroundColor
         self.notifications.textLabel?.textColor = ColorUtil.theme.fontColor
@@ -391,6 +406,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         case 2:
             switch indexPath.row {
             case 0: cell = self.hapticFeedback
+            case 1: cell = self.scrollSidebar
             //case 1: return self.matchSilence
             default: fatalError("Unknown row in section 0")
             }
@@ -529,7 +545,7 @@ class SettingsGeneral: BubbleSettingTableViewController {
         switch section {
         case 0: return 4 + (!pad ? 1 : 0)
         case 1: return 3
-        case 2: return 1
+        case 2: return 2
         case 3: return 1
         case 4: return 3
         case 5: return 2
@@ -637,7 +653,7 @@ class BubbleSettingTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 60
+        return UITableView.automaticDimension
     }
 
     override func loadView() {

--- a/Slide for Reddit/SettingsGestures.swift
+++ b/Slide for Reddit/SettingsGestures.swift
@@ -517,7 +517,7 @@ public class GesturePreviewCell: InsetCell {
         if enabled {
             view.backgroundColor = comment.getColor()
             view.image = UIImage(named: comment.getPhoto())?.getCopy(withSize: CGSize.square(size: 40), withColor: UIColor.white)
-            view.addTapGestureRecognizer {
+            view.addTapGestureRecognizer { (_) in
                 action()
             }
         } else {
@@ -537,7 +537,7 @@ public class GesturePreviewCell: InsetCell {
         if enabled {
             view.backgroundColor = submission.getColor()
             view.image = UIImage(named: submission.getPhoto())?.getCopy(withSize: CGSize.square(size: 40), withColor: UIColor.white)
-            view.addTapGestureRecognizer {
+            view.addTapGestureRecognizer { (_) in
                 action()
             }
         } else {

--- a/Slide for Reddit/SettingsLayout.swift
+++ b/Slide for Reddit/SettingsLayout.swift
@@ -541,9 +541,9 @@ class SettingsLayout: BubbleSettingTableViewController {
         flatModeCell.detailTextLabel?.text = "Disables rounded corners and shadows throughout Slide"
         flatModeCell.detailTextLabel?.numberOfLines = 0
 
-        createCell(reduceElevationCell, reduceElevation, isOn: SettingValues.flatMode, text: "Reduce Elevation")
+        createCell(reduceElevationCell, reduceElevation, isOn: SettingValues.reduceElevation, text: "Reduce Elevation")
         reduceElevationCell.detailTextLabel?.textColor = ColorUtil.theme.fontColor
-        reduceElevationCell.detailTextLabel?.text = "Disables shadows on cardsd and images"
+        reduceElevationCell.detailTextLabel?.text = "Disables shadows on cards and images"
         reduceElevationCell.detailTextLabel?.numberOfLines = 0
 
         doDisables()

--- a/Slide for Reddit/SettingsLayout.swift
+++ b/Slide for Reddit/SettingsLayout.swift
@@ -23,6 +23,11 @@ class SettingsLayout: BubbleSettingTableViewController {
         $0.onTintColor = ColorUtil.baseAccent
     }
 
+    var reduceElevationCell: UITableViewCell = InsetCell(style: .subtitle, reuseIdentifier: "elevate")
+    var reduceElevation = UISwitch().then {
+        $0.onTintColor = ColorUtil.baseAccent
+    }
+
     var hideImageSelftextCell: UITableViewCell = InsetCell(style: .subtitle, reuseIdentifier: "hide")
     var hideImageSelftext = UISwitch().then {
         $0.onTintColor = ColorUtil.baseAccent
@@ -188,6 +193,9 @@ class SettingsLayout: BubbleSettingTableViewController {
         } else if changed == flatMode {
             SettingValues.flatMode = changed.isOn
             UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_flatMode)
+        } else if changed == reduceElevation {
+            SettingValues.reduceElevation = changed.isOn
+            UserDefaults.standard.set(changed.isOn, forKey: SettingValues.pref_reduceElevation)
         }
         SingleSubredditViewController.cellVersion += 1
         MainViewController.needsReTheme = true
@@ -533,6 +541,11 @@ class SettingsLayout: BubbleSettingTableViewController {
         flatModeCell.detailTextLabel?.text = "Disables rounded corners and shadows throughout Slide"
         flatModeCell.detailTextLabel?.numberOfLines = 0
 
+        createCell(reduceElevationCell, reduceElevation, isOn: SettingValues.flatMode, text: "Reduce Elevation")
+        reduceElevationCell.detailTextLabel?.textColor = ColorUtil.theme.fontColor
+        reduceElevationCell.detailTextLabel?.text = "Disables shadows on cardsd and images"
+        reduceElevationCell.detailTextLabel?.numberOfLines = 0
+
         doDisables()
         self.tableView.tableFooterView = UIView()
     }
@@ -587,7 +600,8 @@ class SettingsLayout: BubbleSettingTableViewController {
             case 1: return self.imageCell
             case 2: return self.actionBarCell
             case 3: return self.flatModeCell
-                
+            case 4: return self.reduceElevationCell
+
             default: fatalError("Unknown row in section 1")
             }
         case 2:
@@ -630,7 +644,7 @@ class SettingsLayout: BubbleSettingTableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0: return 1
-        case 1: return 4
+        case 1: return 5
         case 2: return 8
         case 3: return 4
         case 4: return 7

--- a/Slide for Reddit/SettingsLayout.swift
+++ b/Slide for Reddit/SettingsLayout.swift
@@ -519,7 +519,7 @@ class SettingsLayout: BubbleSettingTableViewController {
         createCell(commentTitleCell, commentTitle, isOn: SettingValues.commentsInTitle, text: "Comment count in title")
         createCell(scoreTitleCell, scoreTitle, isOn: SettingValues.scoreInTitle, text: "Post score in title")
         createCell(abbreviateScoreCell, abbreviateScore, isOn: SettingValues.abbreviateScores, text: "Abbreviate post scores (ex: 10k)")
-        createCell(infoBelowTitleCell, infoBelowTitle, isOn: SettingValues.infoBelowTitle, text: "Ppost details below title line")
+        createCell(infoBelowTitleCell, infoBelowTitle, isOn: SettingValues.infoBelowTitle, text: "Post details below title line")
         createCell(domainInfoCell, domainInfo, isOn: SettingValues.domainInInfo, text: "Domain in title")
         createCell(leftThumbCell, leftThumb, isOn: SettingValues.leftThumbnail, text: "Left-side thumbnail")
         createCell(hideCell, hide, isOn: SettingValues.hideButton, text: "Hide post button")

--- a/Slide for Reddit/SettingsPro.swift
+++ b/Slide for Reddit/SettingsPro.swift
@@ -222,7 +222,7 @@ class SettingsPro: UITableViewController, MFMailComposeViewControllerDelegate {
         self.autocache.imageView?.tintColor = ColorUtil.theme.fontColor
         self.autocache.detailTextLabel?.textColor = ColorUtil.theme.fontColor
         
-        three.addTapGestureRecognizer {
+        three.addTapGestureRecognizer { (_) in
             IAPHandler.shared.purchaseMyProduct(index: 0)
             self.alertController = UIAlertController(title: "Upgrading you to Pro!\n\n\n", message: nil, preferredStyle: .alert)
 
@@ -235,7 +235,7 @@ class SettingsPro: UITableViewController, MFMailComposeViewControllerDelegate {
             self.present(self.alertController!, animated: true, completion: nil)
         }
         
-        six.addTapGestureRecognizer {
+        six.addTapGestureRecognizer { (_) in
             IAPHandler.shared.purchaseMyProduct(index: 1)
             self.alertController = UIAlertController(title: "Upgrading you to Pro!\n\n\n", message: nil, preferredStyle: .alert)
 

--- a/Slide for Reddit/ShadowboxLinkViewController.swift
+++ b/Slide for Reddit/ShadowboxLinkViewController.swift
@@ -352,16 +352,16 @@ class ShadowboxLinkViewController: MediaViewController, UIScrollViewDelegate, UI
     }
     
     func populateContent() {
-        self.baseBody.addTapGestureRecognizer {
+        self.baseBody.addTapGestureRecognizer { (_) in
             self.comments(self.view)
         }
-        self.topBody.addTapGestureRecognizer {
+        self.topBody.addTapGestureRecognizer { (_) in
             self.content(self.view)
         }
-        self.upvote.addTapGestureRecognizer {
+        self.upvote.addTapGestureRecognizer { (_) in
             self.upvote(self.upvote)
         }
-        self.downvote.addTapGestureRecognizer {
+        self.downvote.addTapGestureRecognizer { (_) in
             self.downvote(self.downvote)
         }
         if type == .SELF {

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1741,8 +1741,6 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
                 innerPadding += (SettingValues.postViewMode == .COMPACT || isGallery ? 4 : 8) //between title and bottom
             }
         }
-        //thumb off by 12
-        //banner off by 4
         
         var estimatedUsableWidth = itemWidth - paddingLeft - paddingRight
         if thumb {

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -399,6 +399,16 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
     }
 
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        if let cell = cell as? LinkCellView {
+            var row = indexPath.row
+            if hasHeader {
+                row -= 1
+            }
+
+            let submission = dataSource.content[row]
+
+            cell.configure(submission: submission, parent: self, nav: self.navigationController, baseSub: self.sub, np: false)
+        }
     }
 
     override func viewWillLayoutSubviews() {
@@ -2612,7 +2622,6 @@ extension SingleSubredditViewController: UICollectionViewDataSource {
         //cell.panGestureRecognizer?.require(toFail: self.tableView.panGestureRecognizer)
         //ecell.panGestureRecognizer2?.require(toFail: self.tableView.panGestureRecognizer)
 
-        cell.configure(submission: submission, parent: self, nav: self.navigationController, baseSub: self.sub, np: false)
         if row > dataSource.content.count - 4 {
             if !dataSource.loading && !dataSource.nomore {
                 self.dataSource.getData(reload: false)
@@ -2620,7 +2629,6 @@ extension SingleSubredditViewController: UICollectionViewDataSource {
         }
         return cell
     }
-
 }
 
 // MARK: - Collection View Prefetching Data Source

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1787,12 +1787,12 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             } else {
                 totalHeight += max(SettingValues.actionBarMode.isSide() ? 62 : 0, ceil(height)) + imageHeight
             }
-            
+                 
             totalHeight += innerPadding + actionbar + textHeight
             if SettingValues.postViewMode != .CARD || isGallery {
                 totalHeight += 5
             }
-            
+
             totalHeight += CGFloat(submission.gilded && !SettingValues.hideAwards ? 23 : 0)
             
             return CGSize(width: itemWidth, height: totalHeight)

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -265,6 +265,7 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         navigationController?.setToolbarHidden(false, animated: false)
         navigationController?.toolbar.tintColor = ColorUtil.theme.foregroundColor
 
@@ -359,6 +360,8 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         //menuNav?.configureToolbarSwipe()
+        fullWidthBackGestureRecognizer?.isEnabled = true
+        cellGestureRecognizer?.isEnabled = true
         refreshControl.setValue(100, forKey: "_snappingHeight")
 
         if dataSource.loaded && dataSource.content.count > oldCount {
@@ -428,7 +431,6 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             self.fab?.removeFromSuperview()
             self.fab = nil
         }
-
         if let session = (UIApplication.shared.delegate as? AppDelegate)?.session {
             if AccountController.isLoggedIn && AccountController.isGold && !History.currentSeen.isEmpty {
                 do {
@@ -511,7 +513,9 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        
+        fullWidthBackGestureRecognizer?.isEnabled = false
+        cellGestureRecognizer?.isEnabled = false
+
         if fab != nil {
             fab?.removeFromSuperview()
             fab = nil
@@ -2920,10 +2924,15 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
             }
         } else if let nav = self.parent?.navigationController as? SwipeForwardNavigationController {
             nav.fullWidthBackGestureRecognizer.require(toFail: cellGestureRecognizer)
+            nav.interactivePushGestureRecognizer?.require(toFail: cellGestureRecognizer)
             if let interactivePop = nav.interactivePopGestureRecognizer {
                 cellGestureRecognizer.require(toFail: interactivePop)
             }
         }
+        if let swipe = fullWidthBackGestureRecognizer {
+            swipe.require(toFail: cellGestureRecognizer)
+        }
+        
     }
         
     func setupSwipeGesture() {
@@ -2950,6 +2959,11 @@ extension SingleSubredditViewController: UIGestureRecognizerDelegate {
             if let interactivePopGestureRecognizer = self.navigationController?.interactivePopGestureRecognizer, let targets = interactivePopGestureRecognizer.value(forKey: "targets") {
                 setupSwipeWithTarget(fullWidthBackGestureRecognizer as! UIPanGestureRecognizer, targets: targets)
             }
+        }
+        if let nav = navigationController as? SwipeForwardNavigationController {
+            let gesture = nav.fullWidthBackGestureRecognizer
+            nav.interactivePushGestureRecognizer?.require(toFail: fullWidthBackGestureRecognizer)
+            gesture.require(toFail: fullWidthBackGestureRecognizer)
         }
     }
     

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -737,10 +737,10 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             self.fab!.titleLabel?.font = UIFont.systemFont(ofSize: 14)
             
             fabHelper = UIView(frame: self.fab!.frame)
-            fabHelper?.addTapGestureRecognizer(action: {
+            fabHelper?.addTapGestureRecognizer(action: { (_) in
                 self.doFabActions()
             })
-            fabHelper?.addLongTapGestureRecognizer(action: {
+            fabHelper?.addLongTapGestureRecognizer(action: { (_) in
                 self.changeFab()
             })
                         
@@ -763,7 +763,7 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             }, completion: { [weak self] (_) in
                 guard let strongSelf = self else { return }
                 strongSelf.fab?.addTarget(strongSelf, action: #selector(strongSelf.doFabActions), for: .touchUpInside)
-                strongSelf.fab?.addLongTapGestureRecognizer {
+                strongSelf.fab?.addLongTapGestureRecognizer { (_) in
                     strongSelf.changeFab()
                 }
                 
@@ -2128,7 +2128,7 @@ extension SingleSubredditViewController: SubmissionDataSouceDelegate {
         } else {
             self.emptyStateView.setText(title: "Nothing to see here!", message: "All posts were filtered while loading this subreddit. Check your global filters in Slide's Settings, or tap here to view this subreddit's content filters")
             self.emptyStateView.isHidden = false
-            self.emptyStateView.addTapGestureRecognizer {
+            self.emptyStateView.addTapGestureRecognizer { (_) in
                 self.filterContent(true)
             }
         }
@@ -3243,7 +3243,8 @@ public class LinksHeaderCellView: UICollectionViewCell {
             $0.backgroundColor = ColorUtil.getNavColorForSub(sub: sub) ?? ColorUtil.accentColorForSub(sub: sub)
             $0.imageView?.contentMode = .center
         }
-        view.addTapGestureRecognizer(action: {
+        
+        view.addTapGestureRecognizer { (_) in
             self.del?.subscribeSingle(view)
             stack.removeArrangedSubview(view)
             var oldSize = scroll.contentSize
@@ -3251,7 +3252,7 @@ public class LinksHeaderCellView: UICollectionViewCell {
             stack.widthAnchor /==/ oldSize.width
             scroll.contentSize = oldSize
             view.removeFromSuperview()
-        })
+        }
 
         let widthS = CGFloat(30)
 
@@ -3268,9 +3269,9 @@ public class LinksHeaderCellView: UICollectionViewCell {
             $0.setImage(UIImage(sfString: SFSymbol.pencil, overrideString: "edit")?.menuIcon().getCopy(withColor: .white), for: .normal)
             $0.backgroundColor = ColorUtil.getNavColorForSub(sub: sub) ?? ColorUtil.accentColorForSub(sub: sub)
             $0.imageView?.contentMode = .center
-            $0.addTapGestureRecognizer(action: {
+            $0.addTapGestureRecognizer { (_) in
                 PostActions.showPostMenu(self.del!, sub: self.sub)
-            })
+            }
         }
         
         let widthS = CGFloat(30)
@@ -3288,9 +3289,9 @@ public class LinksHeaderCellView: UICollectionViewCell {
             $0.setImage(UIImage(sfString: SFSymbol.infoCircle, overrideString: "info")?.menuIcon().getCopy(withColor: .white), for: .normal)
             $0.backgroundColor = ColorUtil.getNavColorForSub(sub: sub) ?? ColorUtil.accentColorForSub(sub: sub)
             $0.imageView?.contentMode = .center
-            $0.addTapGestureRecognizer(action: {
+            $0.addTapGestureRecognizer { (_) in
                 self.del?.doDisplaySidebar()
-            })
+            }
         }
         
         let widthS = CGFloat(30)
@@ -3325,7 +3326,7 @@ public class LinksHeaderCellView: UICollectionViewCell {
             sortTitle.leftAnchor /==/ sortImage.rightAnchor + 8
             sortTitle.centerYAnchor /==/ sortImage.centerYAnchor
             sortTitle.rightAnchor /==/ sort.rightAnchor
-            sort.addTapGestureRecognizer {
+            sort.addTapGestureRecognizer { (_) in
                 self.del?.showSortMenu(self)
             }
             sortTitle.text = (del?.sort ?? LinkSortType.top).description.uppercased()
@@ -3353,9 +3354,9 @@ public class LinksHeaderCellView: UICollectionViewCell {
                     $0.titleLabel?.textAlignment = .center
                     $0.titleLabel?.font = UIFont.systemFont(ofSize: 12)
                     $0.backgroundColor = ColorUtil.getNavColorForSub(sub: sub) ?? ColorUtil.theme.navIconColor
-                    $0.addTapGestureRecognizer(action: {
+                    $0.addTapGestureRecognizer { (_) in
                         self.del?.doShow(url: link.link!, heroView: nil, finalSize: nil, heroVC: nil, link: RSubmission())
-                    })
+                    }
                 }
                 
                 let widthS = view.currentTitle!.size(with: view.titleLabel!.font).width + CGFloat(45)

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1505,6 +1505,8 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
 
                 if thumb && type == .SELF {
                     thumb = false
+                } else if type == .SELF && !SettingValues.hideImageSelftext && submission.height > 0 {
+                    big = true
                 }
 
                 let fullImage = ContentType.fullImage(t: type)
@@ -1645,6 +1647,8 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
         
         if thumb && type == .SELF {
             thumb = false
+        } else if type == .SELF && !SettingValues.hideImageSelftext && submission.height > 0 {
+            big = true
         }
         
         if !big && !thumb && submission.type != .SELF && submission.type != .NONE { //If a submission has a link but no images, still show the web thumbnail
@@ -1761,6 +1765,10 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
         } else if big && !didRatio {
             let bannerPadding = (SettingValues.postViewMode != .CARD || isGallery) ? (isGallery ? CGFloat(3) : CGFloat(5)) : CGFloat(0)
             submissionHeight = getHeightFromAspectRatio(imageHeight: submissionHeight == 200 ? CGFloat(200) : CGFloat(submission.height == 0 ? 275 : submission.height), imageWidth: CGFloat(submission.width == 0 ? 400 : submission.width), viewWidth: width - paddingLeft - paddingRight - (bannerPadding * 2))
+        }
+        
+        if type == .SELF && !SettingValues.hideImageSelftext && submissionHeight > 200 {
+             submissionHeight = 200
         }
         
         var imageHeight = big && !thumb ? CGFloat(submissionHeight) : CGFloat(0)
@@ -2589,7 +2597,11 @@ extension SingleSubredditViewController: UICollectionViewDataSource {
             case .banner:
                 cell = tableView.dequeueReusableCell(withReuseIdentifier: "banner\(SingleSubredditViewController.cellVersion)", for: indexPath) as! BannerLinkCellView
             default:
-                cell = tableView.dequeueReusableCell(withReuseIdentifier: "text\(SingleSubredditViewController.cellVersion)", for: indexPath) as! TextLinkCellView
+                if !SettingValues.hideImageSelftext && submission.height > 0 {
+                    cell = tableView.dequeueReusableCell(withReuseIdentifier: "banner\(SingleSubredditViewController.cellVersion)", for: indexPath) as! BannerLinkCellView
+                } else {
+                    cell = tableView.dequeueReusableCell(withReuseIdentifier: "text\(SingleSubredditViewController.cellVersion)", for: indexPath) as! TextLinkCellView
+                }
             }
         }
         

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1796,8 +1796,6 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             if SettingValues.postViewMode != .CARD || isGallery {
                 totalHeight += 5
             }
-
-            totalHeight += CGFloat(submission.gilded && !SettingValues.hideAwards ? 23 : 0)
             
             return CGSize(width: itemWidth, height: totalHeight)
         } else { //If layout is nil, just return a size that won't crash the app...

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1738,7 +1738,6 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
         } else {
             innerPadding += (SettingValues.postViewMode == .COMPACT ? 8 : 12) //between top and title
             if SettingValues.actionBarMode.isFull() {
-                innerPadding += (SettingValues.postViewMode == .COMPACT || isGallery ? 8 : 12) //between body and box
                 innerPadding += (SettingValues.postViewMode == .COMPACT || isGallery ? 4 : 8) //between box and end
                 innerPadding -= 5 //LinkCellView L#1191
             } else {

--- a/Slide for Reddit/SingleSubredditViewController.swift
+++ b/Slide for Reddit/SingleSubredditViewController.swift
@@ -1778,16 +1778,14 @@ class SingleSubredditViewController: MediaViewController, AutoplayScrollViewDele
             }
         }
                 
-        let size = CGSize(width: estimatedUsableWidth, height: CGFloat.greatestFiniteMagnitude)
-        let layout = YYTextLayout(containerSize: size, text: CachedTitle.getTitleAttributedString(submission, force: false, gallery: isGallery, full: false, loadImages: false))
-        if let layout = layout {
-            let textSize = layout.textBoundingSize
-
+        let height = CachedTitle.getTitleAttributedString(submission, force: false, gallery: isGallery, full: false, loadImages: false).height(containerWidth: estimatedUsableWidth)
+        
+        if height < 100000 { //Make sure it's a valid height
             var totalHeight = paddingTop + paddingBottom
             if thumb {
-                totalHeight += max(SettingValues.actionBarMode.isSide() ? 62 : 0, ceil(textSize.height), imageHeight)
+                totalHeight += max(SettingValues.actionBarMode.isSide() ? 62 : 0, ceil(height), imageHeight)
             } else {
-                totalHeight += max(SettingValues.actionBarMode.isSide() ? 62 : 0, ceil(textSize.height)) + imageHeight
+                totalHeight += max(SettingValues.actionBarMode.isSide() ? 62 : 0, ceil(height)) + imageHeight
             }
             
             totalHeight += innerPadding + actionbar + textHeight

--- a/Slide for Reddit/SplitMainViewController.swift
+++ b/Slide for Reddit/SplitMainViewController.swift
@@ -861,7 +861,7 @@ extension SplitMainViewController: NavigationHomeDelegate {
     }
     
     func navigation(_ homeViewController: NavigationHomeViewController, didRequestModMenu: Void) {
-        let vc = ModerationViewController()
+        let vc = ModerationOverviewViewController()
         
         doOpen(OpenState.POPOVER_ANY_NAV, homeViewController, toExecute: nil, toPresent: vc)
     }

--- a/Slide for Reddit/SubredditCellView.swift
+++ b/Slide for Reddit/SubredditCellView.swift
@@ -328,7 +328,7 @@ class SubredditCellView: UITableViewCell {
                 submissionView.heightAnchor /==/ 150
                 submissionView.widthAnchor /==/ 200
                 
-                submissionView.addTapGestureRecognizer {
+                submissionView.addTapGestureRecognizer { (_) in
                     VCPresenter.openRedditLink(submission.permalink, nav?.navigationController, nav)
                 }
                 contentView.addArrangedSubview(submissionView)

--- a/Slide for Reddit/SubredditReorderViewController.swift
+++ b/Slide for Reddit/SubredditReorderViewController.swift
@@ -178,8 +178,8 @@ class SubredditReorderViewController: UITableViewController {
                 }
             }
             for m in newMultis {
-                if !self.subs.contains("/m/" + m.displayName) {
-                    self.subs.append("/m/" + m.displayName)
+                if !self.subs.contains("/m/" + m.displayName.replacingOccurrences(of: " ", with: "_")) {
+                    self.subs.append("/m/" + m.displayName.replacingOccurrences(of: " ", with: "_"))
                 }
             }
             self.subs = self.subs.sorted(by: { $0.caseInsensitiveCompare($1) == .orderedAscending })

--- a/Slide for Reddit/SubredditThemeEditViewController.swift
+++ b/Slide for Reddit/SubredditThemeEditViewController.swift
@@ -110,7 +110,7 @@ class SubredditThemeEditViewController: UIViewController, UIColorPickerViewContr
             $0.contentMode = .center
         }
         
-        resetCard.addTapGestureRecognizer {
+        resetCard.addTapGestureRecognizer { (_) in
             self.setupTitleView(self.subreddit)
             self.delegate.didChangeColors(false, color: ColorUtil.getColorForSub(sub: self.subreddit))
             

--- a/Slide for Reddit/SubredditThemeViewController.swift
+++ b/Slide for Reddit/SubredditThemeViewController.swift
@@ -133,7 +133,7 @@ class SubredditThemeViewController: UITableViewController, ColorPickerViewDelega
     var alertController: UIAlertController?
     var count = 0
 
-    @objc func sync(_ selector: AnyObject) {
+    @objc func sync(_ selector: AnyObject) { //TODO - Is this really needed anymore? We do it by default now
         let defaults = UserDefaults.standard
         alertController = UIAlertController(title: "Syncing colors...\n\n\n", message: nil, preferredStyle: .alert)
 

--- a/Slide for Reddit/SubredditToolbarSearchViewController.swift
+++ b/Slide for Reddit/SubredditToolbarSearchViewController.swift
@@ -173,7 +173,7 @@ class SubredditToolbarSearchViewController: UIViewController, UIGestureRecognize
 
         updateAccessibility()
         searchBar.isUserInteractionEnabled = false
-        headerView.addTapGestureRecognizer {
+        headerView.addTapGestureRecognizer { (_) in
             if self.expanded {
                 self.collapse()
             } else {

--- a/Slide for Reddit/Subscriptions.swift
+++ b/Slide for Reddit/Subscriptions.swift
@@ -205,7 +205,9 @@ class Subscriptions {
             } else {
                 for sub in toReturn {
                     subIcons[sub.displayName.lowercased()] = sub.iconImg == "" ? sub.communityIcon : sub.iconImg
-                    subColors[sub.displayName.lowercased()] = sub.keyColor
+                    if sub.keyColor.hexString().lowercased() != "#ffffff" && sub.keyColor.hexString() != "#000000" {
+                        subColors[sub.displayName.lowercased()] = sub.keyColor
+                    }
                 }
 
                 try session.getMineMultireddit({ (result) in
@@ -217,7 +219,9 @@ class Subscriptions {
                         for multi in multireddits {
                             toReturnMultis.append(multi)
                             subIcons["/m/" + multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.iconUrl
-                            subColors["/m/" + multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.keyColor
+                            if multi.keyColor != "#ffffff" && multi.keyColor != "#000000" {
+                                subColors["/m/" + multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.keyColor
+                            }
                         }
                         completion(toReturn, toReturnMultis)
                     }

--- a/Slide for Reddit/Subscriptions.swift
+++ b/Slide for Reddit/Subscriptions.swift
@@ -33,9 +33,6 @@ class Subscriptions {
     
     public static func icon(for sub: String) -> String? {
         var subString = sub.lowercased()
-        if subString.contains("/m/") {
-            subString = sub.replacingOccurrences(of: "/m/", with: "")
-        }
         if let icon = subIcons.object(forKey: subString) as? String, icon != "" {
             return icon
         }
@@ -219,8 +216,8 @@ class Subscriptions {
                     case .success(let multireddits):
                         for multi in multireddits {
                             toReturnMultis.append(multi)
-                            subIcons[multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.iconUrl
-                            subColors[multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.keyColor
+                            subIcons["/m/" + multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.iconUrl
+                            subColors["/m/" + multi.displayName.replacingOccurrences(of: " ", with: "_").lowercased()] = multi.keyColor
                         }
                         completion(toReturn, toReturnMultis)
                     }

--- a/Slide for Reddit/SwipeForwardNavigationController.swift
+++ b/Slide for Reddit/SwipeForwardNavigationController.swift
@@ -92,9 +92,9 @@ class SwipeForwardNavigationController: UINavigationController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
 
-        if let first = pushableViewControllers.first as? SplitMainViewController {
+        if let last = pushableViewControllers.last as? SplitMainViewController {
             pushableViewControllers.removeAll()
-            pushableViewControllers.append(first)
+            pushableViewControllers.append(last)
         } else {
             pushableViewControllers.removeAll()
         }

--- a/Slide for Reddit/TextDisplayStackView.swift
+++ b/Slide for Reddit/TextDisplayStackView.swift
@@ -356,10 +356,10 @@ public class TextDisplayStackView: UIStackView {
                    // TODO: - icon
                     $0.titleLabel?.font = UIFont.systemFont(ofSize: 10)
                     $0.backgroundColor = UIColor.clear
-                    $0.addTapGestureRecognizer(action: {
+                    $0.addTapGestureRecognizer(action: { _ in
                         self.delegate.linkTapped(url: url, text: "")
                     })
-                    $0.addLongTapGestureRecognizer(action: {
+                    $0.addLongTapGestureRecognizer(action: { _ in
                         self.delegate.linkLongTapped(url: url)
                     })
                     counter += 1

--- a/Slide for Reddit/TextLinkCellView.swift
+++ b/Slide for Reddit/TextLinkCellView.swift
@@ -37,11 +37,9 @@ final class TextLinkCellView: LinkCellView {
                 title.horizontalAnchors /==/ innerView.horizontalAnchors + ctwelve
             }
             if !SettingValues.actionBarMode.isFull() {
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ctwelve / 2
-                awardContainerView.bottomAnchor /==/ innerView.bottomAnchor - ctwelve / 2
+                title.bottomAnchor /==/ innerView.bottomAnchor - ctwelve
             } else {
-                title.bottomAnchor /<=/ awardContainerView.topAnchor - ceight / 2
-                awardContainerView.bottomAnchor /==/ box.topAnchor - ceight / 2
+                title.bottomAnchor /<=/ box.topAnchor - ceight
             }
             
             subicon.topAnchor /==/ title.topAnchor

--- a/Slide for Reddit/ThumbnailLinkCellView.swift
+++ b/Slide for Reddit/ThumbnailLinkCellView.swift
@@ -64,11 +64,9 @@ final class ThumbnailLinkCellView: LinkCellView {
             }
             title.topAnchor /==/ innerView.topAnchor + (ctwelve - 5)
             if !SettingValues.actionBarMode.isFull() {
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2 ~ .required
-                awardContainerView.bottomAnchor /<=/ innerView.bottomAnchor - ceight / 2
+                title.bottomAnchor /==/ innerView.bottomAnchor - ceight ~ .required
             } else {
-                title.bottomAnchor /==/ awardContainerView.topAnchor - ceight / 2  ~ .required
-                awardContainerView.bottomAnchor /<=/ box.topAnchor - ceight / 2
+                title.bottomAnchor /==/ box.topAnchor - ceight  ~ .required
             }
             
             subicon.topAnchor /==/ title.topAnchor

--- a/Slide for Reddit/TitleUITextView.swift
+++ b/Slide for Reddit/TitleUITextView.swift
@@ -11,6 +11,54 @@
 import UIKit
 import Foundation
 
+class TitleUITextView: UITextView {
+    var tapDelegate: TextDisplayStackViewDelegate
+    
+    init(delegate: TextDisplayStackViewDelegate, textContainer: NSTextContainer) {
+        self.tapDelegate = delegate
+        super.init(frame: .zero, textContainer: textContainer)
+        
+        self.addTapGestureRecognizer(delegate: self) { (sender) in
+            let tapPoint = sender.location(in: self)
+            let glyphIndex = self.layoutManager.glyphIndex(for: tapPoint, in: self.textContainer, fractionOfDistanceThroughGlyph: nil)
+            let index = self.layoutManager.characterIndexForGlyph(at: glyphIndex)
+            if index < self.textStorage.length {
+                if let attributedURL = self.attributedText.attribute(NSAttributedString.Key.urlAction, at: index, effectiveRange: nil) as? URL {
+                    delegate.linkTapped(url: attributedURL, text: "")
+                }
+            }
+        }
+        
+        self.addLongTapGestureRecognizer(delegate: self) { (sender) in
+            let tapPoint = sender.location(in: self)
+            let glyphIndex = self.layoutManager.glyphIndex(for: tapPoint, in: self.textContainer, fractionOfDistanceThroughGlyph: nil)
+            let index = self.layoutManager.characterIndexForGlyph(at: glyphIndex)
+            if index < self.textStorage.length {
+                if let attributedURL = self.attributedText.attribute(NSAttributedString.Key.urlAction, at: index, effectiveRange: nil) as? URL {
+                    delegate.linkLongTapped(url: attributedURL)
+                }
+            }
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TitleUITextView: UIGestureRecognizerDelegate {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let glyphIndex = self.layoutManager.glyphIndex(for: point, in: self.textContainer, fractionOfDistanceThroughGlyph: nil)
+        let index = self.layoutManager.characterIndexForGlyph(at: glyphIndex)
+        if index < self.textStorage.length {
+            if let attributedURL = self.attributedText.attribute(NSAttributedString.Key.urlAction, at: index, effectiveRange: nil) as? URL {
+                return true
+            }
+        }
+        return false
+    }
+}
+
 class BadgeLayoutManager: NSLayoutManager {
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
@@ -176,6 +224,7 @@ class BadgeLayoutManager: NSLayoutManager {
 
 extension NSAttributedString.Key {
     static let badgeColor: NSAttributedString.Key = .init("badgeColor")
+    static let urlAction: NSAttributedString.Key = .init("urlAction")
 }
 
 //

--- a/Slide for Reddit/TitleUITextView.swift
+++ b/Slide for Reddit/TitleUITextView.swift
@@ -84,10 +84,13 @@ class BadgeLayoutManager: NSLayoutManager {
                 enumerateLineFragments(forGlyphRange: bgStyleGlyphRange) { _, usedRect, textContainer, lineRange, _ in
                     let rangeIntersection = NSIntersectionRange(bgStyleGlyphRange, lineRange)
                     var rect = self.boundingRect(forGlyphRange: rangeIntersection, in: textContainer)
+                    var baseline = 0
+                    baseline = Int(textStorage.attribute(.baselineOffset, at: self.characterIndexForGlyph(at: bgStyleGlyphRange.location), effectiveRange: nil) as? NSNumber ?? 0)
                     // Glyphs can take space outside of the line fragment, and we cannot draw outside of it.
                     // So it is best to restrict the height just to the line fragment.
-                    rect.origin.y = usedRect.origin.y
-                    rect.size.height = usedRect.height
+                    
+                    rect.origin.y = usedRect.origin.y + CGFloat(baseline / 2)
+                    rect.size.height = usedRect.height - CGFloat(baseline) * 1.5
                     let insetTop = CGFloat.zero
                     rects.append(rect.offsetBy(dx: 0, dy: insetTop))
                 }
@@ -141,8 +144,8 @@ class BadgeLayoutManager: NSLayoutManager {
 
             if previousRect != .zero, (currentRect.maxX - previousRect.minX) > cornerRadius {
                 let yDiff = currentRect.minY - previousRect.maxY
-                overlappingLine.move(to: CGPoint(x: max(previousRect.minX, currentRect.minX) + lineWidth / 2, y: previousRect.maxY + yDiff/2))
-                overlappingLine.addLine(to: CGPoint(x: min(previousRect.maxX, currentRect.maxX) - lineWidth / 2, y: previousRect.maxY + yDiff/2))
+                overlappingLine.move(to: CGPoint(x: max(previousRect.minX, currentRect.minX) + lineWidth / 2, y: previousRect.maxY + yDiff / 2))
+                overlappingLine.addLine(to: CGPoint(x: min(previousRect.maxX, currentRect.maxX) - lineWidth / 2, y: previousRect.maxY + yDiff / 2))
 
                 let leftX = max(previousRect.minX, currentRect.minX)
                 let rightX = min(previousRect.maxX, currentRect.maxX)
@@ -163,7 +166,7 @@ class BadgeLayoutManager: NSLayoutManager {
                 rightVerticalJoiningLineShadow.addLine(to: CGPoint(x: rightShadowX, y: currentRect.minY))
             }
 
-            currentCGContext.setShadow(offset: .zero, blur:0, color: UIColor.clear.cgColor)
+            currentCGContext.setShadow(offset: .zero, blur: 0, color: UIColor.clear.cgColor)
 
             // always draw over the overlapping bounds of previous and next rect to hide shadow/borders
             currentCGContext.setStrokeColor(color.cgColor)
@@ -255,8 +258,6 @@ extension NSAttributedString.Key {
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-import Foundation
-import UIKit
 
 public extension NSRange {
 

--- a/Slide for Reddit/TitleUITextView.swift
+++ b/Slide for Reddit/TitleUITextView.swift
@@ -51,8 +51,11 @@ extension TitleUITextView: UIGestureRecognizerDelegate {
         let glyphIndex = self.layoutManager.glyphIndex(for: point, in: self.textContainer, fractionOfDistanceThroughGlyph: nil)
         let index = self.layoutManager.characterIndexForGlyph(at: glyphIndex)
         if index < self.textStorage.length {
-            if let attributedURL = self.attributedText.attribute(NSAttributedString.Key.urlAction, at: index, effectiveRange: nil) as? URL {
-                return true
+            var range = NSRange()
+            if (self.attributedText.attribute(NSAttributedString.Key.urlAction, at: index, effectiveRange: &range) as? URL) != nil {
+                if self.layoutManager.boundingRect(forGlyphRange: range, in: self.textContainer).contains(point) {
+                    return true
+                }
             }
         }
         return false

--- a/Slide for Reddit/UIImage+Extensions.swift
+++ b/Slide for Reddit/UIImage+Extensions.swift
@@ -303,11 +303,21 @@ extension UIImage {
      */
     func roundCorners(proportion: CGFloat) -> UIImage {
         let minValue = min(self.size.width, self.size.height)
-        let radius = minValue/proportion
+        let radius = minValue / proportion
         
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: self.size)
-        UIGraphicsBeginImageContextWithOptions(self.size, false, 1)
+        UIGraphicsBeginImageContextWithOptions(self.size, false, 0)
         UIBezierPath(roundedRect: rect, cornerRadius: radius).addClip()
+        self.draw(in: rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext() ?? self
+        UIGraphicsEndImageContext()
+        return image
+    }
+    
+    func circleCorners(finalSize: CGSize) -> UIImage {
+        let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: finalSize)
+        UIGraphicsBeginImageContextWithOptions(finalSize, false, 0)
+        UIBezierPath(ovalIn: rect).addClip()
         self.draw(in: rect)
         let image = UIGraphicsGetImageFromCurrentImageContext() ?? self
         UIGraphicsEndImageContext()

--- a/Slide for Reddit/UIImage+Extensions.swift
+++ b/Slide for Reddit/UIImage+Extensions.swift
@@ -323,7 +323,6 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return image
     }
-
 }
 
 extension UIImage {


### PR DESCRIPTION
This PR was originally to tackle blended layers and other performance-hurting issues, but I ended up ripping out YYText from the LinkCellView.

- Reduces color blended layers throughout app
- Uses UITextView instead of YYLabel for text rendering, new Async NSTextAttachment to handle images in the title view
- Added methods to trigger click and long click on a custom UITextView, which hooks into previous YYText gesture callbacks
- Removed the Awards view, moved that code back to CachedTitle
- More accurate and faster LinkCellView height estimation
- New option to disable shadows on cards
- Fixed "show selftext image previews" setting
- Improves order of UICollectionViewCell rendering in SingleSubVC to improve performance 
- Adds a new library "Proton", which has some really nice UITextView extensions and a LayoutManager that handles "badge" attributes